### PR TITLE
disable physics process on root disable

### DIFF
--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -16,11 +16,9 @@ func _ready():
 		push_error("Beehave error: Root should have one child")
 		disable()
 		return
+	set_physics_process(enabled)
 
 func _physics_process(delta):
-	if not enabled:
-		return
-
 	blackboard.set("delta", delta)
 
 	var status = self.get_child(0).tick(get_parent(), blackboard)
@@ -52,7 +50,9 @@ func get_last_condition_status():
 
 func enable():
 	self.enabled = true
+	set_physics_process(true)
 
 
 func disable():
 	self.enabled = false
+	set_physics_process(false)


### PR DESCRIPTION
## Description

disable/enable `physics_process` with `enable()` / `disable()` to save some cycles (especially with lots of AI agents running with disabled BTs)


I think we've both ended up inspired by the same BT implementations, I have some slight differences in my implementation so I thought I'd send some PRs to see what you thought, huge fan of the videos btw!

## Addressed issues

## Screenshots

![image](https://user-images.githubusercontent.com/9686709/181756339-b9216e14-298f-4219-830e-38d655cdb32a.png)


## Checklist

- [x] changes performed compatible with Godot 3.x
- [x] changes performed compatible with Godot 4.x (raised in a separate PR against the `2.x` branch in case the change is not compatible with Godot 3.x like specific syntax)
- [x] Unit tests (Godot 4 only after https://github.com/bitbrain/beehave/issues/2 is done)
