### PR TITLE
Allow custom actor on the BeehaveRoot node

### DIFF
--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -9,6 +9,10 @@ const RUNNING = 2
 
 @export var enabled : bool = true
 
+@export_node_path var actor_node_path : NodePath
+
+var actor : Node
+
 @onready var blackboard = Blackboard.new()
 
 func _ready():
@@ -16,26 +20,31 @@ func _ready():
 		push_error("Beehave error: Root should have one child")
 		disable()
 		return
+
+	actor = get_parent()
+	if actor_node_path:
+		actor = get_node(actor_node_path)
+
 	set_physics_process(enabled)
 
 func _physics_process(delta):
 	blackboard.set("delta", delta)
 
-	var status = self.get_child(0).tick(get_parent(), blackboard)
-	
+	var status = self.get_child(0).tick(actor, blackboard)
+
 	if status != RUNNING:
 		blackboard.set("running_action", null)
-	
+
 func get_running_action():
 	if blackboard.has("running_action"):
 		return blackboard.get("running_action")
 	return null
-		
+
 func get_last_condition():
 	if blackboard.has("last_condition"):
 		return blackboard.get("last_condition")
 	return null
-	
+
 func get_last_condition_status():
 	if blackboard.has("last_condition_status"):
 		var status = blackboard.get("last_condition_status")


### PR DESCRIPTION
## Description

Depending on the project it happens that the parent node is not the actor node. 

For example in my case I have the following architecture:
 - PlayerController
    - Character

Or

- AIController (AI type)
  - Character
  - BehaviorRoot node

The purpose of this parameter is to be able to use a node other than the parent node, if the parameter is not specified the code fallback on the default behavior : using the parent node.

## Addressed issues

- Manage nodes in a more flexible way

## Screenshots

<img width="276" alt="Capture d’écran, le 2022-08-04 à 18 50 13" src="https://user-images.githubusercontent.com/3781087/182908238-1788a2ce-af3f-4238-9f3e-7d59639e1402.png">


## Checklist

- [ ] changes performed compatible with Godot 3.x
- [x] changes performed compatible with Godot 4.x (raised in a separate PR against the `2.x` branch in case the change is not compatible with Godot 3.x like specific syntax)
- [ ] Unit tests (Godot 4 only after https://github.com/bitbrain/beehave/issues/2 is done)
