### PR TITLE
Allow user to set process mode

### DIFF
--- a/addons/beehave/nodes/beehave_node.gd
+++ b/addons/beehave/nodes/beehave_node.gd
@@ -4,6 +4,5 @@ class_name BeehaveNode, "../icons/action.svg"
 
 enum { SUCCESS, FAILURE, RUNNING }
 
-
 func tick(actor, blackboard):
 	pass

--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -10,7 +10,8 @@ const RUNNING = 2
 enum PROCESS_MODE {
 	PHYSICS_PROCESS,
 	IDLE,
-	INPUT
+	INPUT,
+	MANUAL
 }
 
 export (bool) var enabled = true

--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -13,7 +13,7 @@ enum PROCESS_MODE {
 	MANUAL
 }
 
-export (PROCESS_MODE) var process_mode = PROCESS_MODE.PHYSICS_PROCESS
+export (PROCESS_MODE) var process_mode = PROCESS_MODE.PHYSICS_PROCESS setget set_process_mode
 export (bool) var enabled = true
 
 onready var blackboard = Blackboard.new()
@@ -61,14 +61,17 @@ func get_last_condition_status():
 			return "RUNNING"
 	return ""
 
-
 func enable():
 	self.enabled = true
 	set_process(process_mode == PROCESS_MODE.IDLE)
 	set_physics_process(process_mode == PROCESS_MODE.PHYSICS_PROCESS)
 
-
 func disable():
 	self.enabled = false
 	set_process(self.enabled)
 	set_physics_process(self.enabled)
+
+func set_process_mode(value):
+	process_mode = value
+	set_process(process_mode == PROCESS_MODE.IDLE)
+	set_physics_process(process_mode == PROCESS_MODE.PHYSICS_PROCESS)

--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -13,6 +13,7 @@ enum PROCESS_MODE {
 	INPUT
 }
 
+export (bool) var enabled = true
 export (PROCESS_MODE) var process_mode = PROCESS_MODE.PHYSICS_PROCESS
 
 onready var blackboard = Blackboard.new()
@@ -45,20 +46,20 @@ func tick(delta):
 	blackboard.set("delta", delta)
 
 	var status = self.get_child(0).tick(get_parent(), blackboard)
-	
+
 	if status != RUNNING:
 		blackboard.set("running_action", null)
-	
+
 func get_running_action():
 	if blackboard.has("running_action"):
 		return blackboard.get("running_action")
 	return null
-		
+
 func get_last_condition():
 	if blackboard.has("last_condition"):
 		return blackboard.get("last_condition")
 	return null
-	
+
 func get_last_condition_status():
 	if blackboard.has("last_condition_status"):
 		var status = blackboard.get("last_condition_status")

--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -32,8 +32,7 @@ func _ready():
 	if actor_node_path:
 		actor = get_node(actor_node_path)
 
-	set_process(enabled and process_mode == ProcessMode.IDLE)
-	set_physics_process(enabled and process_mode == ProcessMode.PHYSICS_PROCESS)
+	set_process_mode(self.process_mode)
 
 func _process(delta):
 	tick(delta)
@@ -72,8 +71,7 @@ func get_last_condition_status():
 
 func enable():
 	self.enabled = true
-	set_process(process_mode == ProcessMode.IDLE)
-	set_physics_process(process_mode == ProcessMode.PHYSICS_PROCESS)
+	set_process_mode(self.process_mode)
 
 func disable():
 	self.enabled = false

--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -64,11 +64,11 @@ func get_last_condition_status():
 
 func enable():
 	self.enabled = true
-	set_process(enabled and process_mode == PROCESS_MODE.IDLE)
-	set_physics_process(enabled and process_mode == PROCESS_MODE.PHYSICS_PROCESS)
+	set_process(process_mode == PROCESS_MODE.IDLE)
+	set_physics_process(process_mode == PROCESS_MODE.PHYSICS_PROCESS)
 
 
 func disable():
 	self.enabled = false
-	set_process(enabled and process_mode == PROCESS_MODE.IDLE)
-	set_physics_process(enabled and process_mode == PROCESS_MODE.PHYSICS_PROCESS)
+	set_process(self.enabled)
+	set_physics_process(self.enabled)

--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -18,9 +18,6 @@ export (PROCESS_MODE) var process_mode = PROCESS_MODE.PHYSICS_PROCESS
 
 onready var blackboard = Blackboard.new()
 
-signal tick_start
-signal tick_end(status)
-
 func _ready():
 	if self.get_child_count() != 1:
 		push_error("Beehave error: Root should have one child")

--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -27,12 +27,10 @@ func _ready():
 	set_physics_process(enabled and process_mode == PROCESS_MODE.PHYSICS_PROCESS)
 
 func _process(delta):
-	if process_mode == PROCESS_MODE.IDLE and enabled:
-		tick(delta)
+	tick(delta)
 
 func _physics_process(delta):
-	if process_mode == PROCESS_MODE.PHYSICS_PROCESS:
-		tick(delta)
+	tick(delta)
 
 func tick(delta):
 	blackboard.set("delta", delta)

--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -10,12 +10,11 @@ const RUNNING = 2
 enum PROCESS_MODE {
 	PHYSICS_PROCESS,
 	IDLE,
-	INPUT,
 	MANUAL
 }
 
-export (bool) var enabled = true
 export (PROCESS_MODE) var process_mode = PROCESS_MODE.PHYSICS_PROCESS
+export (bool) var enabled = true
 
 onready var blackboard = Blackboard.new()
 
@@ -26,7 +25,6 @@ func _ready():
 		return
 	set_process(enabled and process_mode == PROCESS_MODE.IDLE)
 	set_physics_process(enabled and process_mode == PROCESS_MODE.PHYSICS_PROCESS)
-	set_process_input(enabled and process_mode == PROCESS_MODE.INPUT)
 
 func _process(delta):
 	if process_mode == PROCESS_MODE.IDLE and enabled:
@@ -35,10 +33,6 @@ func _process(delta):
 func _physics_process(delta):
 	if process_mode == PROCESS_MODE.PHYSICS_PROCESS:
 		tick(delta)
-
-func _input(event):
-	if process_mode == PROCESS_MODE.INPUT and event.is_action_pressed("tick") and enabled:
-		tick(1.0 / Engine.iterations_per_second)
 
 func tick(delta):
 	blackboard.set("delta", delta)
@@ -74,11 +68,9 @@ func enable():
 	self.enabled = true
 	set_process(enabled and process_mode == PROCESS_MODE.IDLE)
 	set_physics_process(enabled and process_mode == PROCESS_MODE.PHYSICS_PROCESS)
-	set_process_input(enabled and process_mode == PROCESS_MODE.INPUT)
 
 
 func disable():
 	self.enabled = false
 	set_process(enabled and process_mode == PROCESS_MODE.IDLE)
 	set_physics_process(enabled and process_mode == PROCESS_MODE.PHYSICS_PROCESS)
-	set_process_input(enabled and process_mode == PROCESS_MODE.INPUT)

--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -7,13 +7,13 @@ const SUCCESS = 0
 const FAILURE = 1
 const RUNNING = 2
 
-enum PROCESS_MODE {
+enum ProcessMode {
 	PHYSICS_PROCESS,
 	IDLE,
 	MANUAL
 }
 
-export (PROCESS_MODE) var process_mode = PROCESS_MODE.PHYSICS_PROCESS setget set_process_mode
+export (ProcessMode) var process_mode = ProcessMode.PHYSICS_PROCESS setget set_process_mode
 export (bool) var enabled = true
 
 onready var blackboard = Blackboard.new()
@@ -23,8 +23,8 @@ func _ready():
 		push_error("Beehave error: Root should have one child")
 		disable()
 		return
-	set_process(enabled and process_mode == PROCESS_MODE.IDLE)
-	set_physics_process(enabled and process_mode == PROCESS_MODE.PHYSICS_PROCESS)
+	set_process(enabled and process_mode == ProcessMode.IDLE)
+	set_physics_process(enabled and process_mode == ProcessMode.PHYSICS_PROCESS)
 
 func _process(delta):
 	tick(delta)
@@ -63,8 +63,8 @@ func get_last_condition_status():
 
 func enable():
 	self.enabled = true
-	set_process(process_mode == PROCESS_MODE.IDLE)
-	set_physics_process(process_mode == PROCESS_MODE.PHYSICS_PROCESS)
+	set_process(process_mode == ProcessMode.IDLE)
+	set_physics_process(process_mode == ProcessMode.PHYSICS_PROCESS)
 
 func disable():
 	self.enabled = false
@@ -73,5 +73,5 @@ func disable():
 
 func set_process_mode(value):
 	process_mode = value
-	set_process(process_mode == PROCESS_MODE.IDLE)
-	set_physics_process(process_mode == PROCESS_MODE.PHYSICS_PROCESS)
+	set_process(process_mode == ProcessMode.IDLE)
+	set_physics_process(process_mode == ProcessMode.PHYSICS_PROCESS)

--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -1,5 +1,3 @@
 extends Node
 
 class_name BeehaveTree
-
-export (bool) var enabled = true

--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -1,3 +1,5 @@
 extends Node
 
 class_name BeehaveTree
+
+export (bool) var enabled = true

--- a/addons/beehave/nodes/composites/selector.gd
+++ b/addons/beehave/nodes/composites/selector.gd
@@ -4,11 +4,8 @@ class_name SelectorComposite, "../../icons/selector.svg"
 
 func tick(actor, blackboard):
 	for c in get_children():
-		if not c.enabled:
-			continue
-		
 		var response = c.tick(actor, blackboard)
-		
+
 		if c is ConditionLeaf:
 			blackboard.set("last_condition", c)
 			blackboard.set("last_condition_status", response)

--- a/addons/beehave/nodes/composites/selector.gd
+++ b/addons/beehave/nodes/composites/selector.gd
@@ -4,6 +4,9 @@ class_name SelectorComposite, "../../icons/selector.svg"
 
 func tick(actor, blackboard):
 	for c in get_children():
+		if not c.enabled:
+			continue
+		
 		var response = c.tick(actor, blackboard)
 		
 		if c is ConditionLeaf:

--- a/addons/beehave/nodes/composites/selector_star.gd
+++ b/addons/beehave/nodes/composites/selector_star.gd
@@ -11,11 +11,11 @@ var last_execution_index = 0
 
 func tick(actor, blackboard):
 	for c in get_children():
-		if not c.enabled or c.get_index() < last_execution_index:
+		if c.get_index() < last_execution_index:
 			continue
-		
+
 		var response = c.tick(actor, blackboard)
-		
+
 		if c is ConditionLeaf:
 			blackboard.set("last_condition", c)
 			blackboard.set("last_condition_status", response)

--- a/addons/beehave/nodes/composites/selector_star.gd
+++ b/addons/beehave/nodes/composites/selector_star.gd
@@ -11,7 +11,7 @@ var last_execution_index = 0
 
 func tick(actor, blackboard):
 	for c in get_children():
-		if c.get_index() < last_execution_index:
+		if not c.enabled or c.get_index() < last_execution_index:
 			continue
 		
 		var response = c.tick(actor, blackboard)

--- a/addons/beehave/nodes/composites/sequence.gd
+++ b/addons/beehave/nodes/composites/sequence.gd
@@ -4,11 +4,8 @@ class_name SequenceComposite, "../../icons/sequencer.svg"
 
 func tick(actor, blackboard):
 	for c in get_children():
-		if not c.enabled:
-			continue
-		
 		var response = c.tick(actor, blackboard)
-		
+
 		if c is ConditionLeaf:
 			blackboard.set("last_condition", c)
 			blackboard.set("last_condition_status", response)

--- a/addons/beehave/nodes/composites/sequence.gd
+++ b/addons/beehave/nodes/composites/sequence.gd
@@ -4,6 +4,9 @@ class_name SequenceComposite, "../../icons/sequencer.svg"
 
 func tick(actor, blackboard):
 	for c in get_children():
+		if not c.enabled:
+			continue
+		
 		var response = c.tick(actor, blackboard)
 		
 		if c is ConditionLeaf:

--- a/addons/beehave/nodes/composites/sequence_star.gd
+++ b/addons/beehave/nodes/composites/sequence_star.gd
@@ -9,11 +9,11 @@ var successful_index = 0
 
 func tick(actor, blackboard):
 	for c in get_children():
-		if not c.enabled or c.get_index() < successful_index:
+		if c.get_index() < successful_index:
 			continue
-		
+
 		var response = c.tick(actor, blackboard)
-		
+
 		if c is ConditionLeaf:
 			blackboard.set("last_condition", c)
 			blackboard.set("last_condition_status", response)
@@ -26,7 +26,7 @@ func tick(actor, blackboard):
 			return response
 		else:
 			successful_index += 1
-			
+
 	if successful_index == get_child_count():
 		successful_index = 0
 		return SUCCESS

--- a/addons/beehave/nodes/composites/sequence_star.gd
+++ b/addons/beehave/nodes/composites/sequence_star.gd
@@ -9,7 +9,7 @@ var successful_index = 0
 
 func tick(actor, blackboard):
 	for c in get_children():
-		if c.get_index() < successful_index:
+		if not c.enabled or c.get_index() < successful_index:
 			continue
 		
 		var response = c.tick(actor, blackboard)


### PR DESCRIPTION
## Description

I added the option to set `process_node` to the `BeehaveRoot` script. It has a few options:
* `PHYSICS_PROCESS`: Current behavior
* `IDLE`: Process ticks in `_process`
* `MANUAL`: Call the tree's `tick` method manually

(This is mostly useful for the debug tools I'm working on, but it was easy to add so I did it in a separate PR)

## Addressed issues

- Prep for #1, will allow the user to manually call ticks to step through the code

## Screenshots

![image](https://user-images.githubusercontent.com/7832163/183240335-a62a796b-b068-42c5-a7f4-b1813fc62ba8.png)

## Checklist

- [x] changes performed compatible with Godot 3.x
- [ ] changes performed compatible with Godot 4.x (raised in a separate PR against the `2.x` branch in case the change is not compatible with Godot 3.x like specific syntax)
- [ ] Unit tests (Godot 4 only after https://github.com/bitbrain/beehave/issues/2 is done)
