### PR TITLE
Add star icon to sequencer_star sequencer

### DIFF
--- a/addons/beehave/icons/selector_star.svg
+++ b/addons/beehave/icons/selector_star.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <rect id="path12565" x="0" y="-8" width="24" height="24" style="fill:none;fill-rule:nonzero;"/>
+    <g transform="matrix(0.571429,0,0,0.571429,7.42857,-585.2)">
+        <path d="M8,1038.1L5.626,1042.2L1,1043.3L4.236,1046.7L3.877,1051.38L8.016,1049.4L12.174,1051.34L11.778,1046.69L15,1043.3L10.374,1042.2L8,1038.1Z" style="fill:rgb(165,239,172);fill-rule:nonzero;"/>
+    </g>
+    <path id="path12567" d="M8.76,13.6L8.784,13.315L7.405,12L3.81,12L3.81,9.6L0.61,12.8L3.81,16L3.81,13.6L8.76,13.6ZM13.41,8.855L13.375,8.8L13.41,8.8L13.41,8.855ZM3.81,4L11.81,4L11.81,6.4L15.01,3.2L11.81,0L11.81,2.4L2.21,2.4L2.21,7.2L3.81,7.2L3.81,4Z" style="fill:rgb(165,239,172);fill-rule:nonzero;"/>
+</svg>

--- a/addons/beehave/icons/selector_star.svg.import
+++ b/addons/beehave/icons/selector_star.svg.import
@@ -1,0 +1,35 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/selector_star.svg-368af7abfb9842c3f4258786871d1f03.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://addons/beehave/icons/selector_star.svg"
+dest_files=[ "res://.import/selector_star.svg-368af7abfb9842c3f4258786871d1f03.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=false
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+process/normal_map_invert_y=false
+stream=false
+size_limit=0
+detect_3d=false
+svg/scale=1.0

--- a/addons/beehave/icons/sequencer_star.svg
+++ b/addons/beehave/icons/sequencer_star.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <rect id="path13168" x="0" y="-8" width="24" height="24" style="fill:none;fill-rule:nonzero;"/>
+    <g transform="matrix(0.571429,0,0,0.571429,7.42857,-585.2)">
+        <path d="M8,1038.1L5.626,1042.2L1,1043.3L4.236,1046.7L3.877,1051.38L8.016,1049.4L12.174,1051.34L11.778,1046.69L15,1043.3L10.374,1042.2L8,1038.1Z" style="fill:rgb(165,239,172);fill-rule:nonzero;"/>
+    </g>
+    <path id="path13166" d="M0,12.593L1.778,12.593L1.778,10.815L0,10.815L0,12.593ZM5.728,10.815L3.556,10.815L3.556,12.593L7.416,12.593L5.728,10.815ZM0,9.038L1.778,9.038L1.778,7.26L0,7.26L0,9.038ZM10.976,7.26L3.556,7.26L3.556,9.038L9.946,9.038L10.976,7.26ZM13.024,7.26L14.054,9.038L16,9.038L16,7.26L13.024,7.26ZM0,5.482L1.778,5.482L1.778,3.704L0,3.704L0,5.482ZM3.556,3.704L3.556,5.482L16,5.482L16,3.704L3.556,3.704Z" style="fill:rgb(165,239,172);fill-rule:nonzero;"/>
+</svg>

--- a/addons/beehave/icons/sequencer_star.svg.import
+++ b/addons/beehave/icons/sequencer_star.svg.import
@@ -1,0 +1,35 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/sequencer_star.svg-2385cbba0c38b4d4ec43e0996f8a3493.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://addons/beehave/icons/sequencer_star.svg"
+dest_files=[ "res://.import/sequencer_star.svg-2385cbba0c38b4d4ec43e0996f8a3493.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=false
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+process/normal_map_invert_y=false
+stream=false
+size_limit=0
+detect_3d=false
+svg/scale=1.0

--- a/addons/beehave/nodes/composites/selector_star.gd
+++ b/addons/beehave/nodes/composites/selector_star.gd
@@ -4,7 +4,7 @@
 # FAILED or SUCCEEDED
 extends Composite
 
-class_name SelectorStarComposite, "../../icons/selector.svg"
+class_name SelectorStarComposite, "../../icons/selector_star.svg"
 
 
 var last_execution_index = 0

--- a/addons/beehave/nodes/composites/sequence_star.gd
+++ b/addons/beehave/nodes/composites/sequence_star.gd
@@ -3,7 +3,7 @@
 
 extends Composite
 
-class_name SequenceStarComposite, "../../icons/sequencer.svg"
+class_name SequenceStarComposite, "../../icons/sequencer_star.svg"
 
 var successful_index = 0
 


### PR DESCRIPTION
## Description

I like to see the difference between a sequencer and a sequencer star node. I added an icon variant to the node. If this is acceptable, I can add one for selector as well. 
 

## Screenshots

![example](https://user-images.githubusercontent.com/1899013/183512533-a98bd890-a27e-4fe8-aadb-6c482fb5ed06.png)

## Checklist

- [x] changes performed compatible with Godot 3.x
- [x] changes performed compatible with Godot 4.x (raised in a separate PR against the `2.x` branch in case the change is not compatible with Godot 3.x like specific syntax)