### PR TITLE
Add signals to nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Conditions are **leaf nodes** of type `ConditionLeaf`. They should be kept simpl
 class_name IsVisibleCondition
 extends ConditionLeaf
 
-func tick(actor, blackboard):
+func _tick(actor, blackboard):
     if actor.visible:
         return SUCCESS
     return FAILURE
@@ -60,7 +60,7 @@ Actions are **leaf nodes** of type `ActionLeaf`. They can be long running potent
 class_name MakeVisibleAction
 extends ActionLeaf
 
-func tick(actor, blackboard):
+func _tick(actor, blackboard):
     if actor.visible:
         return FAILURE
 	actor.visible = true

--- a/addons/beehave/nodes/beehave_node.gd
+++ b/addons/beehave/nodes/beehave_node.gd
@@ -4,11 +4,9 @@ class_name BeehaveNode, "../icons/action.svg"
 
 enum { SUCCESS, FAILURE, RUNNING }
 
-signal tick_start(node)
 signal tick_end(node, status)
 
 func tick(actor, blackboard):
-	emit_signal("tick_start", self)
 	var result = self._tick(actor, blackboard)
 	emit_signal("tick_end", self, result)
 	return result

--- a/addons/beehave/nodes/beehave_node.gd
+++ b/addons/beehave/nodes/beehave_node.gd
@@ -4,5 +4,14 @@ class_name BeehaveNode, "../icons/action.svg"
 
 enum { SUCCESS, FAILURE, RUNNING }
 
+signal tick_start(node)
+signal tick_end(node, status)
+
 func tick(actor, blackboard):
+	emit_signal("tick_start", self)
+	var result = self._tick(actor, blackboard)
+	emit_signal("tick_end", self, result)
+	return result
+
+func _tick(actor, blackboard):
 	pass

--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -22,8 +22,8 @@ var actor : Node
 
 onready var blackboard = Blackboard.new()
 
-signal tick_start(node)
-signal tick_end(node, status)
+signal tick_start(blackboard)
+signal tick_end(blackboard)
 
 func _ready():
 	if self.get_child_count() != 1:
@@ -44,14 +44,14 @@ func _physics_process(delta):
 	tick(delta)
 
 func tick(delta):
-	emit_signal("tick_start", self)
+	emit_signal("tick_start", self.blackboard)
 	blackboard.set("delta", delta)
 
 	var status = self.get_child(0).tick(actor, blackboard)
 
 	if status != RUNNING:
 		blackboard.set("running_action", null)
-	emit_signal("tick_end", self, status)
+	emit_signal("tick_end", self.blackboard)
 
 func get_running_action():
 	if blackboard.has("running_action"):

--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -22,6 +22,9 @@ var actor : Node
 
 onready var blackboard = Blackboard.new()
 
+signal tick_start(node)
+signal tick_end(node, status)
+
 func _ready():
 	if self.get_child_count() != 1:
 		push_error("Beehave error: Root should have one child")
@@ -36,17 +39,19 @@ func _ready():
 
 func _process(delta):
 	tick(delta)
-  
+
 func _physics_process(delta):
 	tick(delta)
 
 func tick(delta):
+	emit_signal("tick_start", self)
 	blackboard.set("delta", delta)
 
 	var status = self.get_child(0).tick(actor, blackboard)
-	
+
 	if status != RUNNING:
 		blackboard.set("running_action", null)
+	emit_signal("tick_end", self, status)
 
 func get_running_action():
 	if blackboard.has("running_action"):

--- a/addons/beehave/nodes/composites/selector.gd
+++ b/addons/beehave/nodes/composites/selector.gd
@@ -2,7 +2,7 @@ extends Composite
 
 class_name SelectorComposite, "../../icons/selector.svg"
 
-func tick(actor, blackboard):
+func _tick(actor, blackboard):
 	for c in get_children():
 		var response = c.tick(actor, blackboard)
 

--- a/addons/beehave/nodes/composites/selector_star.gd
+++ b/addons/beehave/nodes/composites/selector_star.gd
@@ -9,7 +9,7 @@ class_name SelectorStarComposite, "../../icons/selector.svg"
 
 var last_execution_index = 0
 
-func tick(actor, blackboard):
+func _tick(actor, blackboard):
 	for c in get_children():
 		if c.get_index() < last_execution_index:
 			continue

--- a/addons/beehave/nodes/composites/sequence.gd
+++ b/addons/beehave/nodes/composites/sequence.gd
@@ -2,7 +2,7 @@ extends Composite
 
 class_name SequenceComposite, "../../icons/sequencer.svg"
 
-func tick(actor, blackboard):
+func _tick(actor, blackboard):
 	for c in get_children():
 		var response = c.tick(actor, blackboard)
 

--- a/addons/beehave/nodes/composites/sequence_star.gd
+++ b/addons/beehave/nodes/composites/sequence_star.gd
@@ -7,7 +7,7 @@ class_name SequenceStarComposite, "../../icons/sequencer.svg"
 
 var successful_index = 0
 
-func tick(actor, blackboard):
+func _tick(actor, blackboard):
 	for c in get_children():
 		if c.get_index() < successful_index:
 			continue

--- a/addons/beehave/nodes/decorators/failer.gd
+++ b/addons/beehave/nodes/decorators/failer.gd
@@ -3,7 +3,7 @@ extends Decorator
 class_name AlwaysFailDecorator, "../../icons/fail.svg"
 
 
-func tick(action, blackboard):
+func _tick(action, blackboard):
 	for c in get_children():
 		var response = c.tick(action, blackboard)
 		if response == RUNNING:

--- a/addons/beehave/nodes/decorators/inverter.gd
+++ b/addons/beehave/nodes/decorators/inverter.gd
@@ -3,7 +3,7 @@ extends Decorator
 class_name InverterDecorator, "../../icons/inverter.svg"
 
 
-func tick(action, blackboard):
+func _tick(action, blackboard):
 	for c in get_children():
 		var response = c.tick(action, blackboard)
 

--- a/addons/beehave/nodes/decorators/limiter.gd
+++ b/addons/beehave/nodes/decorators/limiter.gd
@@ -6,7 +6,7 @@ onready var cache_key = 'limiter_%s' % self.get_instance_id()
 
 export (float) var max_count = 0
 
-func tick(actor, blackboard):
+func _tick(actor, blackboard):
 	var current_count = blackboard.get(cache_key)
 
 	if current_count == null:

--- a/addons/beehave/nodes/decorators/succeeder.gd
+++ b/addons/beehave/nodes/decorators/succeeder.gd
@@ -3,7 +3,7 @@ extends Decorator
 class_name AlwaysSucceedDecorator, "../../icons/succeed.svg"
 
 
-func tick(action, blackboard):
+func _tick(action, blackboard):
 	for c in get_children():
 		var response = c.tick(action, blackboard)
 		if response == RUNNING:


### PR DESCRIPTION
## Description

This was primarily for assisting with debugging, but has a few notes:

1. The user should implement their own `_tick` method if they want the signals to fire. I did it this way to be consistent with the other methods like `_draw` to draw on the canvas, where you call `update` to force a redraw.
2. The user should still call `tick` on each child node to process them
3. If the user overrides the `tick` method accidentally nothing will break. This ensures old code still works (I've been testing it on your demo project)

## Addressed issues

- Related to #1 

## Checklist

- [x] changes performed compatible with Godot 3.x
- [ ] changes performed compatible with Godot 4.x (raised in a separate PR against the `2.x` branch in case the change is not compatible with Godot 3.x like specific syntax)
- [ ] Unit tests (Godot 4 only after https://github.com/bitbrain/beehave/issues/2 is done)
