### PR TITLE
fixed wrong indent of `return FAILURE` statement in `failer.gd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ extends ActionLeaf
 func tick(actor, blackboard):
     if actor.visible:
         return FAILURE
-	actor.visible = true
+    actor.visible = true
     return SUCCESS
 ```
 

--- a/addons/beehave/nodes/decorators/failer.gd
+++ b/addons/beehave/nodes/decorators/failer.gd
@@ -8,4 +8,4 @@ func tick(action, blackboard):
 		var response = c.tick(action, blackboard)
 		if response == RUNNING:
 			return RUNNING
-		return FAILURE
+	return FAILURE


### PR DESCRIPTION
## Description & Addressed issues

see #26 

## Checklist

- [ ] changes performed compatible with Godot 3.x
- [ ] changes performed compatible with Godot 4.x (raised in a separate PR against the `2.x` branch in case the change is not compatible with Godot 3.x like specific syntax)
- [ ] Unit tests (Godot 4 only after https://github.com/bitbrain/beehave/issues/2 is done)
