### PR TITLE
Added documentation comments

### DIFF
--- a/addons/beehave/blackboard.gd
+++ b/addons/beehave/blackboard.gd
@@ -1,3 +1,5 @@
+## The blackboard is an object that can be used to store and access data between
+## multiple nodes of the behaviour tree.
 class_name Blackboard extends RefCounted
 
 var blackboard: Dictionary = {}

--- a/addons/beehave/nodes/beehave_node.gd
+++ b/addons/beehave/nodes/beehave_node.gd
@@ -1,3 +1,5 @@
+## A node in the behaviour tree. Every node must return `SUCCESS`, `FAILURE` or
+## `RUNNING` when ticked.
 class_name BeehaveNode extends BeehaveTree
 @icon("../icons/action.svg")
 

--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -1,3 +1,4 @@
+## Controls the flow of execution of the entire behaviour tree.
 class_name BeehaveRoot extends BeehaveTree
 @icon("../icons/tree.svg")
 

--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -1,2 +1,3 @@
+## Base class for all parts of the behaviour tree.
 class_name BeehaveTree extends Node
 @icon("../icons/icon.svg")

--- a/addons/beehave/nodes/composites/composite.gd
+++ b/addons/beehave/nodes/composites/composite.gd
@@ -1,3 +1,4 @@
+## A Composite node controls the flow of execution of its children in a specific manner.
 extends BeehaveNode
 
 class_name Composite

--- a/addons/beehave/nodes/composites/selector.gd
+++ b/addons/beehave/nodes/composites/selector.gd
@@ -1,3 +1,7 @@
+## Selector nodes will attempt to execute each of its children until one of
+## them return `SUCCESS`. If all children return `FAILURE`, this node will also
+## return `FAILURE`. This node will attempt to process all its children every
+## single tick, even if one of them is currently `RUNNING` already.
 extends Composite
 
 class_name SelectorComposite

--- a/addons/beehave/nodes/composites/selector_star.gd
+++ b/addons/beehave/nodes/composites/selector_star.gd
@@ -1,7 +1,7 @@
-# Special implementation of a selector that will
-# "wait" for running nodes and will not re-attempt
-# to execute previous nodes until that node is either
-# FAILED or SUCCEEDED
+## Selector Star nodes will attempt to execute each of its children until one of
+## them return `SUCCESS`. If all children return `FAILURE`, this node will also
+## return `FAILURE`. This node will skip all previous child nodes that were
+## executed prior, in case one of the children is currently in `RUNNING` state.
 extends Composite
 
 class_name SelectorStarComposite

--- a/addons/beehave/nodes/composites/sequence.gd
+++ b/addons/beehave/nodes/composites/sequence.gd
@@ -1,3 +1,8 @@
+## Sequence nodes will attempt to execute all of its children and report
+## `SUCCESS` in case all of the children report a `SUCCESS` status code.
+## If at least one child reports a `FAILURE` status code, this node will also
+## return `FAILURE`. This node will attempt to process all its children every
+## single tick, even if one of them is currently `RUNNING` already.
 extends Composite
 
 class_name SequenceComposite

--- a/addons/beehave/nodes/composites/sequence_star.gd
+++ b/addons/beehave/nodes/composites/sequence_star.gd
@@ -1,6 +1,8 @@
-# Special implementation of sequencer who will execute
-# successful nodes only once until all nodes were successful
-
+## Sequence Star nodes will attempt to execute all of its children and report
+## `SUCCESS` in case all of the children report a `SUCCESS` status code.
+## If at least one child reports a `FAILURE` status code, this node will also
+## return `FAILURE`. This node will skip all previous child nodes that succeeded
+## prior, in case one of the children is currently in `RUNNING` state
 extends Composite
 
 class_name SequenceStarComposite

--- a/addons/beehave/nodes/decorators/decorator.gd
+++ b/addons/beehave/nodes/decorators/decorator.gd
@@ -1,3 +1,5 @@
+## Decorator nodes are used to transform the result received by its child.
+## Must only have one child.
 extends BeehaveNode
 
 class_name Decorator

--- a/addons/beehave/nodes/decorators/failer.gd
+++ b/addons/beehave/nodes/decorators/failer.gd
@@ -1,3 +1,4 @@
+## A Failer node will always return a `FAILURE` status code.
 extends Decorator
 
 class_name AlwaysFailDecorator

--- a/addons/beehave/nodes/decorators/inverter.gd
+++ b/addons/beehave/nodes/decorators/inverter.gd
@@ -1,3 +1,5 @@
+## An inverter will return `FAILURE` in case it's child returns a `SUCCESS` status
+## code or `SUCCESS` in case its child returns a `FAILURE` status code.
 extends Decorator
 
 class_name InverterDecorator

--- a/addons/beehave/nodes/decorators/limiter.gd
+++ b/addons/beehave/nodes/decorators/limiter.gd
@@ -1,3 +1,5 @@
+## The limiter will execute its child `x` amount of times. When the number of
+## maximum ticks is reached, it will return a `FAILURE` status code.
 extends Decorator
 
 class_name LimiterDecorator

--- a/addons/beehave/nodes/decorators/succeeder.gd
+++ b/addons/beehave/nodes/decorators/succeeder.gd
@@ -1,3 +1,4 @@
+## A succeeder node will always return a `SUCCESS` status code.
 extends Decorator
 
 class_name AlwaysSucceedDecorator

--- a/addons/beehave/nodes/leaves/action.gd
+++ b/addons/beehave/nodes/leaves/action.gd
@@ -1,3 +1,7 @@
+## Actions are leaf nodes that define a task to be performed by an actor.
+## Their execution can be long running, potentially being called across multiple
+## frame executions. In this case, the node should return `RUNNING` until the
+## action is completed.
 extends Leaf
 
 class_name ActionLeaf

--- a/addons/beehave/nodes/leaves/condition.gd
+++ b/addons/beehave/nodes/leaves/condition.gd
@@ -1,3 +1,5 @@
+## Conditions are leaf nodes that either return SUCCESS or FAILURE depending on
+## a single simple condition. They should never return `RUNNING`.
 extends Leaf
 
 class_name ConditionLeaf

--- a/addons/beehave/nodes/leaves/leaf.gd
+++ b/addons/beehave/nodes/leaves/leaf.gd
@@ -1,3 +1,4 @@
+## Base class for all leaf nodes of the tree.
 extends BeehaveNode
 
 class_name Leaf


### PR DESCRIPTION
## Description

I've added documentation comments for all classes except for the plugin.gd script. Some of the documentation texts were changed based on [here](https://www.behaviortree.dev/docs/learn-the-basics/BT_basics). English is not my first language so it would be wise to check if there's any typos or something. 

## Addressed issues

#51 - Add documentation comments

## Screenshots

![image](https://user-images.githubusercontent.com/21160216/204092592-2edba118-b158-4689-add7-38af4ba325cf.png)

You can see them when you hover or mouse but, if you just click on the nodes the description in the bottom will not update (it will show the description for the previous selected node). I had to click on Recent and then select the node for the description to show. Seems to be a godot bug. I'm using godot 4 beta 6.

Also, I've used the `` sytax for the status codes but godot does not render them as markdown syntax. VS Code does, so I think it's neat to keep it this way:

![image](https://user-images.githubusercontent.com/21160216/204092849-3c369464-cb3f-4ab8-affd-5b85ff9ba8b5.png)

## Checklist

- [ ] ~changes performed compatible with Godot 3.x~ (this will only be done for godot 4.x)
- [X] changes performed compatible with Godot 4.x (raised in a separate PR against the `2.x` branch in case the change is not compatible with Godot 3.x like specific syntax)
