### PR TITLE
Added interrupt method for long running actions

### DIFF
--- a/addons/beehave/nodes/beehave_node.gd
+++ b/addons/beehave/nodes/beehave_node.gd
@@ -4,6 +4,11 @@ class_name BeehaveNode extends BeehaveTree
 @icon("../icons/action.svg")
 
 ## Executes this node and returns a status code.
-## This method must be overwritten. 
+## This method must be overwritten.
 func tick(actor: Node, blackboard: Blackboard) -> int:
 	return SUCCESS
+
+
+## Called when this node needs to be interrupted before it can return FAILURE or SUCCESS.
+func interrupt(actor: Node, blackboard: Blackboard) -> void:
+	pass

--- a/addons/beehave/nodes/beehave_root.gd
+++ b/addons/beehave/nodes/beehave_root.gd
@@ -32,16 +32,22 @@ func _ready() -> void:
 
 func _physics_process(delta: float) -> void:
 	blackboard.set_value("delta", delta)
-
 	var status = self.get_child(0).tick(actor, blackboard)
 
-	if status != RUNNING:
-		blackboard.set_value("running_action", null)
+	# Updates the current running action.
+	var running_action = get_running_action() if status == RUNNING else null
+	blackboard.set_value("running_action", running_action)
 
 
 func get_running_action() -> ActionLeaf:
-	if blackboard.has_value("running_action"):
-		return blackboard.get_value("running_action")
+	var node = get_child(0)
+	while node != null:
+		if node is Composite:
+			node = (node as Composite).running_child
+		elif node is ActionLeaf:
+			return node
+	
+	push_error("Beehave error: Could not find running action in tree root '%s'." % name)
 	return null
 
 

--- a/addons/beehave/nodes/composites/composite.gd
+++ b/addons/beehave/nodes/composites/composite.gd
@@ -4,6 +4,16 @@ extends BeehaveNode
 class_name Composite
 @icon("../../icons/category_composite.svg")
 
+
+var running_child: BeehaveNode = null
+
+
 func _ready():
 	if self.get_child_count() < 1:
 		push_error("BehaviorTree Error: Composite %s should have at least one child (NodePath: %s)" % [self.name, self.get_path()])
+
+
+func interrupt(actor: Node, blackboard: Blackboard) -> void:
+	if running_child != null:
+		running_child.interrupt(actor, blackboard)
+		running_child = null

--- a/addons/beehave/nodes/composites/selector.gd
+++ b/addons/beehave/nodes/composites/selector.gd
@@ -16,8 +16,11 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 			blackboard.set_value("last_condition_status", response)
 
 		if response != FAILURE:
-			if c is ActionLeaf and response == RUNNING:
-				blackboard.set_value("running_action", c)
+			if response == SUCCESS:
+				# Interrupt any child that was RUNNING before.
+				interrupt(actor, blackboard)
+			else: # RUNNING
+				running_child = c
 			return response
 
 	return FAILURE

--- a/addons/beehave/nodes/composites/selector_star.gd
+++ b/addons/beehave/nodes/composites/selector_star.gd
@@ -21,10 +21,10 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 			blackboard.set_value("last_condition_status", response)
 
 		if response != FAILURE:
-			if c is ActionLeaf and response == RUNNING:
-				blackboard.set_value("running_action", c)
 			if response == SUCCESS:
 				last_execution_index = 0
+			else: # RUNNING
+				running_child = c
 			return response
 		else:
 			last_execution_index += 1

--- a/addons/beehave/nodes/composites/sequence.gd
+++ b/addons/beehave/nodes/composites/sequence.gd
@@ -17,8 +17,11 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 			blackboard.set_value("last_condition_status", response)
 
 		if response != SUCCESS:
-			if c is ActionLeaf and response == RUNNING:
-				blackboard.set_value("running_action", c)
+			if response == FAILURE:
+				# Interrupt any child that was RUNNING before.
+				interrupt(actor, blackboard)
+			else: # RUNNING
+				running_child = c
 			return response
 
 	return SUCCESS

--- a/addons/beehave/nodes/composites/sequence_star.gd
+++ b/addons/beehave/nodes/composites/sequence_star.gd
@@ -24,8 +24,8 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		if response != SUCCESS:
 			if response == FAILURE:
 				successful_index = 0
-			if c is ActionLeaf and response == RUNNING:
-				blackboard.set_value("running_action", c)
+			else: # RUNNING
+				running_child = c
 			return response
 		else:
 			successful_index += 1


### PR DESCRIPTION
## Description

This PR adds an `interrupt` method for the tree nodes when a long running action need to be prematurely interrupted as well as logic in `Selector` and `Sequence` nodes to call this method.

## Addressed issues

#45

## Screenshots

Well, no screenshots but here's a sample project I used to test things.
[beehave_sample.zip](https://github.com/bitbrain/beehave/files/10204162/beehave_sample.zip)

