### PR TITLE
Bundle only addons/beehave and script_templates in releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Normalize EOL for all files that Git considers text files.
+* text=auto eol=lf
+
+# Ignore some files when exporting to a ZIP.
+# Only include the addons folder when downloading from the Asset Library.
+/**                  export-ignore
+/addons              !export-ignore
+/addons/**           !export-ignore
+
+# Also include script templates.
+/script_templates    !export-ignore
+/script_templates/** !export-ignore

--- a/addons/beehave/LICENSE
+++ b/addons/beehave/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 bitbrain
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Description

This works for godot-3.x branch already, but there's no .gitattributes file for godot-4.x, so I added it here too. Now it should also include the script_templates directory. I also copied the LICENSE to addons/beehave as advised in #33

## Addressed issues

- #33 

