### PR TITLE
:bug: correctly interrupt SelectorStar and SequenceStar

### DIFF
--- a/addons/beehave/nodes/composites/selector_star.gd
+++ b/addons/beehave/nodes/composites/selector_star.gd
@@ -30,3 +30,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 	last_execution_index = 0
 	return FAILURE
+	
+func interrupt(actor: Node, blackboard: Blackboard) -> void:
+	last_execution_index = 0
+	super(actor, blackboard)

--- a/addons/beehave/nodes/composites/sequence_star.gd
+++ b/addons/beehave/nodes/composites/sequence_star.gd
@@ -35,3 +35,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 	else:
 		successful_index = 0
 		return FAILURE
+		
+func interrupt(actor: Node, blackboard: Blackboard) -> void:
+	successful_index = 0
+	super(actor, blackboard)

--- a/project.godot
+++ b/project.godot
@@ -80,6 +80,11 @@ _global_script_classes=[{
 "path": "res://addons/beehave/nodes/composites/selector.gd"
 }, {
 "base": "Composite",
+"class": &"SelectorRandomComposite",
+"language": &"GDScript",
+"path": "res://addons/beehave/nodes/composites/selector_random.gd"
+}, {
+"base": "Composite",
 "class": &"SelectorStarComposite",
 "language": &"GDScript",
 "path": "res://addons/beehave/nodes/composites/selector_star.gd"
@@ -88,6 +93,11 @@ _global_script_classes=[{
 "class": &"SequenceComposite",
 "language": &"GDScript",
 "path": "res://addons/beehave/nodes/composites/sequence.gd"
+}, {
+"base": "Composite",
+"class": &"SequenceRandomComposite",
+"language": &"GDScript",
+"path": "res://addons/beehave/nodes/composites/sequence_random.gd"
 }, {
 "base": "Composite",
 "class": &"SequenceStarComposite",
@@ -109,8 +119,10 @@ _global_script_class_icons={
 "Leaf": "res://addons/beehave/icons/category_leaf.svg",
 "LimiterDecorator": "res://addons/beehave/icons/limiter.svg",
 "SelectorComposite": "res://addons/beehave/icons/selector.svg",
+"SelectorRandomComposite": "res://addons/beehave/icons/selector_random.svg",
 "SelectorStarComposite": "res://addons/beehave/icons/selector_reactive.svg",
 "SequenceComposite": "res://addons/beehave/icons/sequence.svg",
+"SequenceRandomComposite": "res://addons/beehave/icons/sequence_random.svg",
 "SequenceStarComposite": "res://addons/beehave/icons/sequence_reactive.svg"
 }
 


### PR DESCRIPTION
## Description

There was a bug where on interrupt selector star and sequence star may have an incorrect index set, leading to undesired behaviour on the next execution.