### PR TITLE
:bug: ensure Blackboard can be used concurrently

### DIFF
--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -46,12 +46,12 @@ func _physics_process(delta: float) -> void:
 	if Engine.is_editor_hint():
 		return
 	
-	blackboard.set_value("delta", delta)
+	blackboard.set_value("delta", delta, str(actor.get_instance_id()))
 	var status = self.get_child(0).tick(actor, blackboard)
 
 	# Updates the current running action.
 	var running_action = get_running_action() if status == RUNNING else null
-	blackboard.set_value("running_action", running_action)
+	blackboard.set_value("running_action", running_action, str(actor.get_instance_id()))
 
 
 func _get_configuration_warnings() -> PackedStringArray:
@@ -79,14 +79,14 @@ func get_running_action() -> ActionLeaf:
 
 
 func get_last_condition() -> Variant:
-	if blackboard.has_value("last_condition"):
-		return blackboard.get_value("last_condition")
+	if blackboard.has_value("last_condition", str(actor.get_instance_id())):
+		return blackboard.get_value("last_condition", str(actor.get_instance_id()))
 	return null
 
 
 func get_last_condition_status() -> String:
-	if blackboard.has_value("last_condition_status"):
-		var status = blackboard.get_value("last_condition_status")
+	if blackboard.has_value("last_condition_status", str(actor.get_instance_id())):
+		var status = blackboard.get_value("last_condition_status", str(actor.get_instance_id()))
 		if status == SUCCESS:
 			return "SUCCESS"
 		elif status == FAILURE:

--- a/addons/beehave/nodes/composites/selector.gd
+++ b/addons/beehave/nodes/composites/selector.gd
@@ -11,8 +11,8 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		var response = c.tick(actor, blackboard)
 		
 		if c is ConditionLeaf:
-			blackboard.set_value("last_condition", c)
-			blackboard.set_value("last_condition_status", response)
+			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))
+			blackboard.set_value("last_condition_status", response, str(actor.get_instance_id()))
 
 		if response != FAILURE:
 			if response == SUCCESS:

--- a/addons/beehave/nodes/composites/selector_random.gd
+++ b/addons/beehave/nodes/composites/selector_random.gd
@@ -21,8 +21,8 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		var response = c.tick(actor, blackboard)
 		
 		if c is ConditionLeaf:
-			blackboard.set_value("last_condition", c)
-			blackboard.set_value("last_condition_status", response)
+			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))
+			blackboard.set_value("last_condition_status", response, str(actor.get_instance_id()))
 		
 		if response == RUNNING:
 			running_child = c

--- a/addons/beehave/nodes/composites/selector_star.gd
+++ b/addons/beehave/nodes/composites/selector_star.gd
@@ -16,8 +16,8 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		var response = c.tick(actor, blackboard)
 		
 		if c is ConditionLeaf:
-			blackboard.set_value("last_condition", c)
-			blackboard.set_value("last_condition_status", response)
+			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))
+			blackboard.set_value("last_condition_status", response, str(actor.get_instance_id()))
 
 		if response != FAILURE:
 			if response == SUCCESS:

--- a/addons/beehave/nodes/composites/sequence.gd
+++ b/addons/beehave/nodes/composites/sequence.gd
@@ -12,8 +12,8 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		var response = c.tick(actor, blackboard)
 		
 		if c is ConditionLeaf:
-			blackboard.set_value("last_condition", c)
-			blackboard.set_value("last_condition_status", response)
+			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))
+			blackboard.set_value("last_condition_status", response, str(actor.get_instance_id()))
 
 		if response != SUCCESS:
 			if response == FAILURE:

--- a/addons/beehave/nodes/composites/sequence_random.gd
+++ b/addons/beehave/nodes/composites/sequence_random.gd
@@ -26,8 +26,8 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		var response = c.tick(actor, blackboard)
 		
 		if c is ConditionLeaf:
-			blackboard.set_value("last_condition", c)
-			blackboard.set_value("last_condition_status", response)
+			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))
+			blackboard.set_value("last_condition_status", response, str(actor.get_instance_id()))
 		
 		if response == RUNNING:
 			running_child = c

--- a/addons/beehave/nodes/composites/sequence_star.gd
+++ b/addons/beehave/nodes/composites/sequence_star.gd
@@ -17,8 +17,8 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		var response = c.tick(actor, blackboard)
 		
 		if c is ConditionLeaf:
-			blackboard.set_value("last_condition", c)
-			blackboard.set_value("last_condition_status", response)
+			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))
+			blackboard.set_value("last_condition_status", response, str(actor.get_instance_id()))
 
 		if response != SUCCESS:
 			if response == FAILURE:

--- a/addons/beehave/nodes/decorators/inverter.gd
+++ b/addons/beehave/nodes/decorators/inverter.gd
@@ -14,7 +14,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 			return SUCCESS
 
 		if c is Leaf and response == RUNNING:
-			blackboard.set_value("running_action", c)
+			blackboard.set_value("running_action", c, str(actor.get_instance_id()))
 		return RUNNING
 	
 	# Decorators must have a child. This should be unreachable code.

--- a/addons/beehave/nodes/decorators/limiter.gd
+++ b/addons/beehave/nodes/decorators/limiter.gd
@@ -9,13 +9,13 @@ class_name LimiterDecorator extends Decorator
 @export var max_count : float = 0
 
 func tick(actor: Node, blackboard: Blackboard) -> int:
-	var current_count = blackboard.get_value(cache_key)
+	var current_count = blackboard.get_value(cache_key, str(actor.get_instance_id()))
 
 	if current_count == null:
 		current_count = 0
 
 	if current_count <= max_count:
-		blackboard.set_value(cache_key, current_count + 1)
+		blackboard.set_value(cache_key, current_count + 1, str(actor.get_instance_id()))
 		return self.get_child(0).tick(actor, blackboard)
 	else:
 		return FAILURE

--- a/tests/BeehaveTestScene.tscn
+++ b/tests/BeehaveTestScene.tscn
@@ -58,3 +58,38 @@ current = true
 
 [node name="Blackboard" type="Node" parent="."]
 script = ExtResource("2_3263a")
+
+[node name="AnotherSprite" type="Sprite2D" parent="."]
+position = Vector2(182, 180)
+scale = Vector2(0.1, 0.1)
+texture = SubResource("CompressedTexture2D_atdvc")
+
+[node name="BeehaveTree" type="Node" parent="AnotherSprite" node_paths=PackedStringArray("blackboard")]
+script = ExtResource("1_cp4ud")
+actor_node_path = NodePath("")
+blackboard = NodePath("../../Blackboard")
+
+[node name="SelectorComposite" type="Node" parent="AnotherSprite/BeehaveTree"]
+script = ExtResource("3_cw13w")
+
+[node name="SequenceComposite" type="Node" parent="AnotherSprite/BeehaveTree/SelectorComposite"]
+script = ExtResource("4_o25g4")
+
+[node name="HasPositivePosition" parent="AnotherSprite/BeehaveTree/SelectorComposite/SequenceComposite" instance=ExtResource("4_2l8k0")]
+
+[node name="SetModulateColor" parent="AnotherSprite/BeehaveTree/SelectorComposite/SequenceComposite" instance=ExtResource("6_5pvqg")]
+modulate_color = Color(1, 0, 0, 1)
+
+[node name="SequenceComposite2" type="Node" parent="AnotherSprite/BeehaveTree/SelectorComposite"]
+script = ExtResource("4_o25g4")
+
+[node name="HasNegativePosition" parent="AnotherSprite/BeehaveTree/SelectorComposite/SequenceComposite2" instance=ExtResource("8_4s5rt")]
+
+[node name="SetModulateColor" parent="AnotherSprite/BeehaveTree/SelectorComposite/SequenceComposite2" instance=ExtResource("6_5pvqg")]
+modulate_color = Color(0, 0, 1, 1)
+
+[node name="SetModulateColor" parent="AnotherSprite/BeehaveTree/SelectorComposite" instance=ExtResource("6_5pvqg")]
+modulate_color = Color(1, 1, 1, 1)
+
+[node name="Camera2D" type="Camera2D" parent="AnotherSprite"]
+current = true


### PR DESCRIPTION
## Description

https://github.com/bitbrain/beehave/pull/99 introduced an issue where multiple trees could reference the same `Blackboard` but it would override internal, tree specific information about nodes that were last run. This PR ensures that that information is local to the actor.