### PR TITLE
:zap: improve performance of get_running_action

### DIFF
--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -49,9 +49,10 @@ func _physics_process(delta: float) -> void:
 	blackboard.set_value("delta", delta, str(actor.get_instance_id()))
 	var status = self.get_child(0).tick(actor, blackboard)
 
-	# Updates the current running action.
-	var running_action = get_running_action() if status == RUNNING else null
-	blackboard.set_value("running_action", running_action, str(actor.get_instance_id()))
+	# Clear running action if nothing is running
+	if status != RUNNING:
+		blackboard.set_value("running_action", null, str(actor.get_instance_id()))
+	
 
 
 func _get_configuration_warnings() -> PackedStringArray:
@@ -67,21 +68,11 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 
 func get_running_action() -> ActionLeaf:
-	var node = get_child(0)
-	while node != null:
-		if node is Composite:
-			node = (node as Composite).running_child
-		elif node is ActionLeaf:
-			return node
-	
-	push_error("Beehave error: Could not find running action in tree root '%s'." % name)
-	return null
+	return blackboard.get_value("running_action", null, str(actor.get_instance_id()))
 
 
-func get_last_condition() -> Variant:
-	if blackboard.has_value("last_condition", str(actor.get_instance_id())):
-		return blackboard.get_value("last_condition", null, str(actor.get_instance_id()))
-	return null
+func get_last_condition() -> ConditionLeaf:
+	return blackboard.get_value("last_condition", null, str(actor.get_instance_id()))
 
 
 func get_last_condition_status() -> String:

--- a/addons/beehave/nodes/composites/selector.gd
+++ b/addons/beehave/nodes/composites/selector.gd
@@ -20,6 +20,8 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 				interrupt(actor, blackboard)
 			else: # RUNNING
 				running_child = c
+				if c is ActionLeaf:
+					blackboard.set_value("running_action", c, str(actor.get_instance_id()))
 			return response
 
 	return FAILURE

--- a/addons/beehave/nodes/composites/selector_random.gd
+++ b/addons/beehave/nodes/composites/selector_random.gd
@@ -26,6 +26,8 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		
 		if response == RUNNING:
 			running_child = c
+			if c is ActionLeaf:
+				blackboard.set_value("running_action", c, str(actor.get_instance_id()))
 		else:
 			_children_bag.erase(c)
 		

--- a/addons/beehave/nodes/composites/selector_star.gd
+++ b/addons/beehave/nodes/composites/selector_star.gd
@@ -24,6 +24,8 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 				last_execution_index = 0
 			else: # RUNNING
 				running_child = c
+				if c is ActionLeaf:
+					blackboard.set_value("running_action", c, str(actor.get_instance_id()))
 			return response
 		else:
 			last_execution_index += 1

--- a/addons/beehave/nodes/composites/sequence.gd
+++ b/addons/beehave/nodes/composites/sequence.gd
@@ -21,6 +21,8 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 				interrupt(actor, blackboard)
 			else: # RUNNING
 				running_child = c
+				if c is ActionLeaf:
+					blackboard.set_value("running_action", c, str(actor.get_instance_id()))
 			return response
 
 	return SUCCESS

--- a/addons/beehave/nodes/composites/sequence_random.gd
+++ b/addons/beehave/nodes/composites/sequence_random.gd
@@ -31,6 +31,8 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		
 		if response == RUNNING:
 			running_child = c
+			if c is ActionLeaf:
+				blackboard.set_value("running_action", c, str(actor.get_instance_id()))
 		else:
 			_children_bag.erase(c)
 		

--- a/addons/beehave/nodes/composites/sequence_star.gd
+++ b/addons/beehave/nodes/composites/sequence_star.gd
@@ -25,6 +25,8 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 				successful_index = 0
 			else: # RUNNING
 				running_child = c
+				if c is ActionLeaf:
+					blackboard.set_value("running_action", c, str(actor.get_instance_id()))
 			return response
 		else:
 			successful_index += 1

--- a/addons/beehave/nodes/decorators/failer.gd
+++ b/addons/beehave/nodes/decorators/failer.gd
@@ -8,5 +8,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 	for c in get_children():
 		var response = c.tick(actor, blackboard)
 		if response == RUNNING:
+			if c is ActionLeaf:
+				blackboard.set_value("running_action", c, str(actor.get_instance_id()))
 			return RUNNING
 	return FAILURE

--- a/addons/beehave/nodes/decorators/inverter.gd
+++ b/addons/beehave/nodes/decorators/inverter.gd
@@ -13,8 +13,9 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		if response == FAILURE:
 			return SUCCESS
 
-		if c is Leaf and response == RUNNING:
+		if c is ActionLeaf:
 			blackboard.set_value("running_action", c, str(actor.get_instance_id()))
+			
 		return RUNNING
 	
 	# Decorators must have a child. This should be unreachable code.

--- a/addons/beehave/nodes/decorators/limiter.gd
+++ b/addons/beehave/nodes/decorators/limiter.gd
@@ -16,6 +16,10 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 	if current_count <= max_count:
 		blackboard.set_value(cache_key, current_count + 1, str(actor.get_instance_id()))
-		return self.get_child(0).tick(actor, blackboard)
+		var child = self.get_child(0)
+		var response = child.tick(actor, blackboard)
+		if child is ActionLeaf and response == RUNNING:
+			blackboard.set_value("running_action", child, str(actor.get_instance_id()))
+		return response
 	else:
 		return FAILURE

--- a/addons/beehave/nodes/decorators/succeeder.gd
+++ b/addons/beehave/nodes/decorators/succeeder.gd
@@ -8,5 +8,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 	for c in get_children():
 		var response = c.tick(actor, blackboard)
 		if response == RUNNING:
+			if c is ActionLeaf:
+				blackboard.set_value("running_action", c, str(actor.get_instance_id()))
 			return RUNNING
 	return SUCCESS

--- a/examples/actions/SetModulateColor.gd
+++ b/examples/actions/SetModulateColor.gd
@@ -1,8 +1,28 @@
 extends ActionLeaf
 
-@export var modulate_color:Color
+@export var modulate_color:Color = Color.WHITE
+@export var interpolation_time:float = 3.0
+
+var current_color
+var tween
 
 func tick(actor: Node, _blackboard: Blackboard) -> int:
-	actor.modulate = modulate_color
-	return SUCCESS
+	
+	if current_color != modulate_color and actor.modulate != modulate_color:
+		if tween != null:
+			tween.stop()
+		current_color = modulate_color
+		tween = create_tween()\
+		.set_ease(Tween.EASE_IN_OUT)\
+		.set_trans(Tween.TRANS_CUBIC)
+		tween.tween_property(actor, "modulate", current_color, interpolation_time)\
+		.finished.connect(_finished)
+		
+	if current_color != null:
+		return RUNNING
+	else:
+		return SUCCESS
 
+func _finished() -> void:
+	current_color = null
+	tween = null

--- a/tests/BeehaveTestScene.gd
+++ b/tests/BeehaveTestScene.gd
@@ -2,7 +2,8 @@ extends Node2D
 
 @onready var sprite := $Sprite2D
 @onready var tree := %BeehaveTree
-@onready var label := %Label
+@onready var condition_label := %ConditionLabel
+@onready var action_label := %ActionLabel
 
 
 func _process(delta:float) -> void:
@@ -19,4 +20,11 @@ func _process(delta:float) -> void:
 		sprite.position.y += 200 * delta
 	
 	if tree.get_last_condition():
-		label.text = str(tree.get_last_condition(), " -> ", tree.get_last_condition_status())
+		condition_label.text = str(tree.get_last_condition(), " -> ", tree.get_last_condition_status())
+	else:
+		condition_label.text = "no condition"
+		
+	if tree.get_running_action():
+		action_label.text = str(tree.get_running_action(), " -> RUNNING")
+	else:
+		action_label.text = "no running action"

--- a/tests/BeehaveTestScene.tscn
+++ b/tests/BeehaveTestScene.tscn
@@ -52,7 +52,6 @@ script = ExtResource("4_o25g4")
 modulate_color = Color(0, 0, 1, 1)
 
 [node name="SetModulateColor" parent="Sprite2D/BeehaveTree/SelectorComposite" instance=ExtResource("6_5pvqg")]
-modulate_color = Color(1, 1, 1, 1)
 
 [node name="Camera2D" type="Camera2D" parent="Sprite2D"]
 
@@ -89,14 +88,20 @@ script = ExtResource("4_o25g4")
 modulate_color = Color(0, 0, 1, 1)
 
 [node name="SetModulateColor" parent="AnotherSprite/AnotherTree/SelectorComposite" instance=ExtResource("6_5pvqg")]
-modulate_color = Color(1, 1, 1, 1)
 
 [node name="Camera2D" type="Camera2D" parent="AnotherSprite"]
 current = true
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
-[node name="Label" type="Label" parent="CanvasLayer"]
-unique_name_in_owner = true
+[node name="VBoxContainer" type="VBoxContainer" parent="CanvasLayer"]
 offset_right = 40.0
-offset_bottom = 23.0
+offset_bottom = 40.0
+
+[node name="ConditionLabel" type="Label" parent="CanvasLayer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="ActionLabel" type="Label" parent="CanvasLayer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2


### PR DESCRIPTION
The old method looped through the entire tree every single time `get_running_action` was called. Now, the action is computed dynamically within the tree.