### PR TITLE
Fix: Adapt usage of typed Arrays for RC1

### DIFF
--- a/addons/beehave/blackboard.gd
+++ b/addons/beehave/blackboard.gd
@@ -6,7 +6,9 @@ class_name Blackboard extends Node
 var blackboard: Dictionary = {}
 
 func keys() -> Array[String]:
-	return blackboard.keys().duplicate()
+	var keys: Array[String]
+	keys.assign(blackboard.keys().duplicate())
+	return keys
 
 
 func set_value(key: Variant, value: Variant, blackboard_name: String = 'default') -> void:

--- a/addons/beehave/nodes/composites/selector_random.gd
+++ b/addons/beehave/nodes/composites/selector_random.gd
@@ -57,7 +57,8 @@ func interrupt(actor: Node, blackboard: Blackboard) -> void:
 
 
 func _get_reversed_indexes() -> Array[int]:
-	var reversed = range(_children_bag.size())
+	var reversed: Array[int]
+	reversed.assign(range(_children_bag.size()))
 	reversed.reverse()
 	return reversed
 

--- a/addons/beehave/nodes/composites/sequence_random.gd
+++ b/addons/beehave/nodes/composites/sequence_random.gd
@@ -64,7 +64,8 @@ func interrupt(actor: Node, blackboard: Blackboard) -> void:
 
 
 func _get_reversed_indexes() -> Array[int]:
-	var reversed = range(_children_bag.size())
+	var reversed: Array[int]
+	reversed.assign(range(_children_bag.size()))
 	reversed.reverse()
 	return reversed
 


### PR DESCRIPTION
## Description

Godot 4 RC1 is stricter with its usage of typed arrays. This PR will adapt the usage of typed arrays so it won't throw errors anymore.
