### PR TITLE
Fix: Check child count before applying interrupt

### DIFF
--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -120,7 +120,8 @@ func get_last_condition_status() -> String:
 	
 ## interrupts this tree if anything was running
 func interrupt() -> void:
-	self.get_child(0).interrupt(actor, blackboard)
+	if self.get_child_count() != 0:
+		self.get_child(0).interrupt(actor, blackboard)
 
 
 func enable() -> void:

--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -121,7 +121,9 @@ func get_last_condition_status() -> String:
 ## interrupts this tree if anything was running
 func interrupt() -> void:
 	if self.get_child_count() != 0:
-		self.get_child(0).interrupt(actor, blackboard)
+		var first_child = self.get_child(0)
+		if "interrupt" in first_child:
+			first_child.interrupt(actor, blackboard)
 
 
 func enable() -> void:

--- a/test/UnitTestScene.tscn
+++ b/test/UnitTestScene.tscn
@@ -76,3 +76,30 @@ limit = 4
 [node name="SharedCountUpAction2" type="Node" parent="ThirdNode/BeehaveTree/SequenceComposite"]
 unique_name_in_owner = true
 script = ExtResource("6_brhwp")
+
+[node name="EmptyTree" type="Node2D" parent="."]
+
+[node name="BeehaveTree" type="Node" parent="EmptyTree" node_paths=PackedStringArray("blackboard")]
+script = ExtResource("2_phgmn")
+blackboard = NodePath("")
+
+[node name="OnlyOneActionTree" type="Node2D" parent="."]
+
+[node name="BeehaveTree" type="Node" parent="OnlyOneActionTree" node_paths=PackedStringArray("blackboard")]
+script = ExtResource("2_phgmn")
+enabled = false
+actor_node_path = NodePath("..")
+blackboard = NodePath("")
+
+[node name="CountUpAction" type="Node" parent="OnlyOneActionTree/BeehaveTree"]
+script = ExtResource("6_brhwp")
+
+[node name="DeactivatedTree" type="Node2D" parent="."]
+
+[node name="BeehaveTree" type="Node" parent="DeactivatedTree" node_paths=PackedStringArray("blackboard")]
+script = ExtResource("2_phgmn")
+actor_node_path = NodePath("..")
+blackboard = NodePath("")
+
+[node name="CountUpAction" type="Node" parent="DeactivatedTree/BeehaveTree"]
+script = ExtResource("6_brhwp")


### PR DESCRIPTION
## Description

Currently, an out of bounds error will happen when:
- there's no child node inside the BeehaveTree
- BeehaveTree.enabled = false
