### PR TITLE
Move Blackboard initialization to export line

### DIFF
--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -27,7 +27,7 @@ signal tree_disabled
 		return enabled
 
 @export_node_path var actor_node_path : NodePath
-@export var blackboard:Blackboard
+@export var blackboard:Blackboard = Blackboard.new()
 
 var actor : Node
 var status : int = -1
@@ -43,9 +43,6 @@ func _ready() -> void:
 		push_error("Beehave error: Root %s should have one child (NodePath: %s)" % [self.name, self.get_path()])
 		disable()
 		return
-		
-	if not blackboard:
-		blackboard = Blackboard.new()
 
 	actor = get_parent()
 	if actor_node_path:


### PR DESCRIPTION
## Description

If BeehaveTree.enabled = false, the blackboard property will always be null if not otherwise assigned

This PR is there to allow editing a blackboard even if the tree is deactivated - reducing the need to add ifs outside the BeehaveTree itself. Also, correct me if I'm wrong - if the Tree starts out disabled, will it ever have a Blackboard (if not assigned)?