### PR TITLE
:bug: dynamically create or release inner Blackboard based on assigning external blackboards

### DIFF
--- a/test/beehave_tree_test.gd
+++ b/test/beehave_tree_test.gd
@@ -59,7 +59,7 @@ func test_interrupt_running_action() -> void:
 	scene.count_up_action.status = BeehaveNode.RUNNING
 	scene.beehave_tree._physics_process(1.0)
 	scene.beehave_tree._physics_process(1.0)
-	assert_that(scene.beehave_tree.internal_blackboard.get_value("custom_value")).is_equal(2)
+	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(2)
 	scene.beehave_tree.interrupt()
-	assert_that(scene.beehave_tree.internal_blackboard.get_value("custom_value")).is_equal(0)
+	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(0)
 	assert_that(scene.count_up_action.status).is_equal(BeehaveNode.FAILURE)

--- a/test/beehave_tree_test.gd
+++ b/test/beehave_tree_test.gd
@@ -59,7 +59,7 @@ func test_interrupt_running_action() -> void:
 	scene.count_up_action.status = BeehaveNode.RUNNING
 	scene.beehave_tree._physics_process(1.0)
 	scene.beehave_tree._physics_process(1.0)
-	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(2)
+	assert_that(scene.beehave_tree.internal_blackboard.get_value("custom_value")).is_equal(2)
 	scene.beehave_tree.interrupt()
-	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(0)
+	assert_that(scene.beehave_tree.internal_blackboard.get_value("custom_value")).is_equal(0)
 	assert_that(scene.count_up_action.status).is_equal(BeehaveNode.FAILURE)


### PR DESCRIPTION
## Description

There is currently an issue where someone can just assign `blackboard` to another property and break this addon. This PR comes with several changes:

- the internal blackboard is not considered an orphan any longer but is properly attached to the scene tree
- the behaviour tree now hosts multiple children (this may break things but we can discuss this on here)
- when assigning/unassigning blackboards at runtime, beehave will take care of automatically creating a new blackboard. Currently, values stored in the "old" blackboard will not be "moved over" (might be okay?)

## Addressed issues

- closes #127 