### PR TITLE
Enforce US Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Using behavior trees, Beehave makes it simple to create highly adaptive AI that 
 
 # 📚 Getting started
 
-Behavior trees are a modular way to build AI logic for your game. For simple AI, behaviour trees are definitely overkill, however, for more complex AI interactions, behaviour trees can help you to better manage changes and re-use logic across all NPCs.
+Behavior trees are a modular way to build AI logic for your game. For simple AI, behavior trees are definitely overkill, however, for more complex AI interactions, behavior trees can help you to better manage changes and re-use logic across all NPCs.
 
 ![example](assets/example.png)
 

--- a/addons/beehave/blackboard.gd
+++ b/addons/beehave/blackboard.gd
@@ -1,5 +1,5 @@
 ## The blackboard is an object that can be used to store and access data between
-## multiple nodes of the behaviour tree.
+## multiple nodes of the behavior tree.
 @icon("icons/blackboard.svg")
 class_name Blackboard extends Node
 

--- a/addons/beehave/nodes/beehave_node.gd
+++ b/addons/beehave/nodes/beehave_node.gd
@@ -1,4 +1,4 @@
-## A node in the behaviour tree. Every node must return `SUCCESS`, `FAILURE` or
+## A node in the behavior tree. Every node must return `SUCCESS`, `FAILURE` or
 ## `RUNNING` when ticked.
 @tool
 class_name BeehaveNode extends Node

--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -1,4 +1,4 @@
-## Controls the flow of execution of the entire behaviour tree.
+## Controls the flow of execution of the entire behavior tree.
 @tool
 @icon("../icons/tree.svg")
 class_name BeehaveTree extends Node

--- a/addons/beehave/plugin.cfg
+++ b/addons/beehave/plugin.cfg
@@ -1,7 +1,7 @@
 [plugin]
 
 name="Beehave"
-description="🐝 Behaviour Tree addon for Godot Engine"
+description="🐝 Behavior Tree addon for Godot Engine"
 author="bitbrain"
 version="2.6.3"
 script="plugin.gd"

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,11 +10,11 @@ Using behavior trees, Beehave makes it simple to create highly adaptive AI that 
 
 # 🐝 Features
 
-**🤖 Node based - build behaviour trees within your scene tree**
+**🤖 Node based - build behavior trees within your scene tree**
 
-**🐛 Debug view - a dedicated debug view to analyse your behaviour at runtime**
+**🐛 Debug view - a dedicated debug view to analyze your behavior at runtime**
 
-**🚗 Performance - built-in monitors to track performance of your behaviour trees**
+**🚗 Performance - built-in monitors to track performance of your behavior trees**
 
 **🍯 Active community - used by hundreds of game developers**
 

--- a/docs/composites.md
+++ b/docs/composites.md
@@ -1,2 +1,2 @@
 # Composites
-In order to create logic flows based on conditions and actions, we need to compose them through so called composites. A composite is a node that executes its children in a particularorder. They can be split into the two categories, Selector, and Sequence. 
+In order to create logic flows based on conditions and actions, we need to compose them through so called composites. A composite is a node that executes its children in a particular order. They can be split into the two categories, Selector, and Sequence. 

--- a/docs/contribute 2.md
+++ b/docs/contribute 2.md
@@ -15,7 +15,7 @@ You can run the unit tests by right-clicking the `test` folder and selecting `Ru
 
 ## 🐝 Adding a new node
 
-In case you want to introduce a new node, feel free to [raise a pull request](https://github.com/bitbrain/beehave/compare). Check the issues tab for any discussions on new nodes, as it is a great place to gather feedback before you spend time on implementing it. Ensure to also introduce an icon for your node that is following the colour scheme:
+In case you want to introduce a new node, feel free to [raise a pull request](https://github.com/bitbrain/beehave/compare). Check the issues tab for any discussions on new nodes, as it is a great place to gather feedback before you spend time on implementing it. Ensure to also introduce an icon for your node that is following the color scheme:
 
 - Utility nodes: `#C689FF`
 - Leafs: `#FFB649`

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -15,7 +15,7 @@ You can run the unit tests by right-clicking the `test` folder and selecting `Ru
 
 ## 🐝 Adding a new node
 
-In case you want to introduce a new node, feel free to [raise a pull request](https://github.com/bitbrain/beehave/compare). Check the issues tab for any discussions on new nodes, as it is a great place to gather feedback before you spend time on implementing it. Ensure to also introduce an icon for your node that is following the colour scheme:
+In case you want to introduce a new node, feel free to [raise a pull request](https://github.com/bitbrain/beehave/compare). Check the issues tab for any discussions on new nodes, as it is a great place to gather feedback before you spend time on implementing it. Ensure to also introduce an icon for your node that is following the color scheme:
 
 - Utility nodes: `#C689FF`
 - Leafs: `#FFB649`

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -1,14 +1,14 @@
 # Learn how Beehave works
 
-Behaviour trees are a modular way to build AI logic for your game. For simple AI, behaviour trees are definitely overkill, however, for more complex AI interactions, behaviour trees can help you to better manage changes and re-use logic across all NPCs.
+Behavior trees are a modular way to build AI logic for your game. For simple AI, behavior trees are definitely overkill, however, for more complex AI interactions, behavior trees can help you to better manage changes and re-use logic across all NPCs.
 
 ## What is a behavior tree?
 
-In a nutshell, a behaviour tree is a Godot Node that can be added as a child to other Godot nodes within the scene tree. It will run its logic every frame tick and modify the parent node accordingly.
+In a nutshell, a behavior tree is a Godot Node that can be added as a child to other Godot nodes within the scene tree. It will run its logic every frame tick and modify the parent node accordingly.
 
-In more theoretical terms, a behaviour tree consists of so called **nodes** - each node can be of a different type with different purposes. Those are described further down below in more detail. Every node has a `tick(actor, blackboard)` method that can be used to execute custom logic. When the `tick` function is called, beehave expects a return status of either `SUCCESS`, `RUNNING` or `FAILURE`.
+In more theoretical terms, a behavior tree consists of so called **nodes** - each node can be of a different type with different purposes. Those are described further down below in more detail. Every node has a `tick(actor, blackboard)` method that can be used to execute custom logic. When the `tick` function is called, beehave expects a return status of either `SUCCESS`, `RUNNING` or `FAILURE`.
 
-In **Beehave**, every behaviour tree is of type `BeehaveTree`. Attach that node to any node to any other node you want to apply the behaviour tree to.
+In **Beehave**, every behavior tree is of type `BeehaveTree`. Attach that node to any node to any other node you want to apply the behavior tree to.
 
 ## Tutorial (Godot 3.5+)
 

--- a/test/e2e_test.gd
+++ b/test/e2e_test.gd
@@ -11,7 +11,7 @@ func create_scene() -> Node2D:
 	return auto_free(load(__source).instantiate())
 	
 
-func test_changing_to_all_colours() -> void:
+func test_changing_to_all_colors() -> void:
 	var scene = create_scene()
 	var runner := scene_runner(scene)
 	# speed up the test


### PR DESCRIPTION
## Description

- Replaced the few words found using UK spelling with it's US alternative
  - In the README files
  - In the documentation
  - In code comments
  - In test func name
- Fixed a minor typo where a space was missing


## Addressed issues

- #151 

## Screenshots

N/A
