### PR TITLE
fix flaky test

### DIFF
--- a/GdUnitRunner.cfg
+++ b/GdUnitRunner.cfg
@@ -1,1 +1,1 @@
-{"included":{"res://test/":[]},"server_port":31002,"skipped":{},"version":"1.0"}
+{"included":{"res://test/beehave_tree_test.gd":["test_get_last_condition"]},"server_port":31002,"skipped":{},"version":"1.0"}

--- a/examples/BeehaveTestScene.tscn
+++ b/examples/BeehaveTestScene.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=12 format=3 uid="uid://y24m3r3eydsu"]
 
 [ext_resource type="Script" path="res://examples/BeehaveTestScene.gd" id="1_s45or"]
-[ext_resource type="Texture2D" uid="uid://cnte7abibxvas" path="res://splash.png" id="2_yf6a3"]
+[ext_resource type="Texture2D" uid="uid://bphl1evimyk6u" path="res://splash.png" id="2_yf6a3"]
 [ext_resource type="Script" path="res://examples/ColorChangingSprite.gd" id="3_4a21r"]
 [ext_resource type="Script" path="res://addons/beehave/nodes/beehave_tree.gd" id="3_hid2l"]
 [ext_resource type="Script" path="res://addons/beehave/nodes/composites/selector.gd" id="4_8ftoq"]

--- a/test/beehave_tree_test.gd
+++ b/test/beehave_tree_test.gd
@@ -28,7 +28,7 @@ func test_nothing_running_before_first_tick() -> void:
 func test_get_last_condition() -> void:
 	var scene = create_scene()
 	var runner := scene_runner(scene)
-	await runner.simulate_frames(10)
+	await runner.simulate_frames(100)
 	assert_that(scene.beehave_tree.get_running_action()).is_null()
 	assert_that(scene.beehave_tree.get_last_condition()).is_not_null()
 	assert_that(scene.beehave_tree.get_last_condition_status()).is_equal('SUCCESS')
@@ -37,7 +37,7 @@ func test_disabled() -> void:
 	var scene = create_scene()
 	var runner := scene_runner(scene)
 	scene.beehave_tree.disable()
-	await runner.simulate_frames(10)
+	await runner.simulate_frames(50)
 	assert_bool(scene.beehave_tree.enabled).is_false()
 	assert_that(scene.beehave_tree.get_running_action()).is_null()
 	assert_that(scene.beehave_tree.get_last_condition()).is_null()
@@ -48,7 +48,7 @@ func test_reenabled() -> void:
 	var runner := scene_runner(scene)
 	scene.beehave_tree.disable()
 	scene.beehave_tree.enable()
-	await runner.simulate_frames(10)
+	await runner.simulate_frames(50)
 	assert_bool(scene.beehave_tree.enabled).is_true()
 	assert_that(scene.beehave_tree.get_last_condition()).is_not_null()
 	


### PR DESCRIPTION
We need to increase the timeout from 10ms to 100ms in some tests to avoid flakyness.