### PR TITLE
:bug: do not spam console with errors

### DIFF
--- a/addons/beehave/debug/debugger.gd
+++ b/addons/beehave/debug/debugger.gd
@@ -12,6 +12,10 @@ func _has_capture(prefix: String) -> bool:
 
 
 func _capture(message: String, data: Array, session_id: int) -> bool:
+	# in case the behavior tree has invalid setup this might be null
+	if debugger_tab == null:
+		return false
+	
 	if message == "beehave:register_tree":
 		debugger_tab.register_tree(data[0])
 		return true

--- a/addons/beehave/nodes/composites/selector.gd
+++ b/addons/beehave/nodes/composites/selector.gd
@@ -51,5 +51,5 @@ func interrupt(actor: Node, blackboard: Blackboard) -> void:
 
 func get_class_name() -> Array[StringName]:
 	var classes := super()
-	classes.push_back(&"SelectorStarComposite")
+	classes.push_back(&"SelectorComposite")
 	return classes

--- a/addons/beehave/nodes/composites/selector_reactive.gd
+++ b/addons/beehave/nodes/composites/selector_reactive.gd
@@ -4,7 +4,7 @@
 ## If a child returns `RUNNING` it will restart.
 @tool
 @icon("../../icons/selector_reactive.svg")
-class_name ReactiveSelectorComposite extends Composite
+class_name SelectorReactiveComposite extends Composite
 
 func tick(actor: Node, blackboard: Blackboard) -> int:
 	for c in get_children():
@@ -39,5 +39,5 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 func get_class_name() -> Array[StringName]:
 	var classes := super()
-	classes.push_back(&"ReactiveSelectorComposite")
+	classes.push_back(&"SelectorReactiveComposite")
 	return classes

--- a/addons/beehave/nodes/composites/selector_reactive.gd
+++ b/addons/beehave/nodes/composites/selector_reactive.gd
@@ -39,5 +39,5 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 func get_class_name() -> Array[StringName]:
 	var classes := super()
-	classes.push_back(&"SelectorComposite")
+	classes.push_back(&"ReactiveSelectorComposite")
 	return classes

--- a/addons/beehave/nodes/composites/sequence_reactive.gd
+++ b/addons/beehave/nodes/composites/sequence_reactive.gd
@@ -50,3 +50,9 @@ func interrupt(actor: Node, blackboard: Blackboard) -> void:
 	
 func _reset() -> void:
 	successful_index = 0
+
+
+func get_class_name() -> Array[StringName]:
+	var classes := super()
+	classes.push_back(&"SequenceReactiveComposite")
+	return classes

--- a/docs/features/_sidebar.md
+++ b/docs/features/_sidebar.md
@@ -1,2 +1,0 @@
-* [Blackboard](blackboard.md)
-* [🪲 Debugging](debugging.md)

--- a/docs/features/blackboard.md
+++ b/docs/features/blackboard.md
@@ -1,3 +1,0 @@
-# <img src="../assets/icons/blackboard.svg" width="26em"/> Blackboard
-
-todo

--- a/docs/features/debugging.md
+++ b/docs/features/debugging.md
@@ -1,3 +1,0 @@
-# Debugging
-
-todo


### PR DESCRIPTION
## Description

in case the tree uses invalid scripts it can happen that errors will be spammed by the debugger. This fixes the issue.