### PR TITLE
Add TimeLimiter node

### DIFF
--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -124,7 +124,7 @@ func _physics_process(delta: float) -> void:
 
 func tick() -> int:
 	var child := self.get_child(0)
-	if status == -1:
+	if status != RUNNING:
 		child.before_run(actor, blackboard)
 
 	status = child.tick(actor, blackboard)

--- a/addons/beehave/nodes/composites/composite.gd
+++ b/addons/beehave/nodes/composites/composite.gd
@@ -30,6 +30,10 @@ func interrupt(actor: Node, blackboard: Blackboard) -> void:
 		running_child = null
 
 
+func after_run(actor: Node, blackboard: Blackboard) -> void:
+	running_child = null
+
+
 func get_class_name() -> Array[StringName]:
 	var classes := super()
 	classes.push_back(&"Composite")

--- a/addons/beehave/nodes/composites/selector.gd
+++ b/addons/beehave/nodes/composites/selector.gd
@@ -43,6 +43,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 func after_run(actor: Node, blackboard: Blackboard) -> void:
 	last_execution_index = 0
+	super(actor, blackboard)
 
 
 func interrupt(actor: Node, blackboard: Blackboard) -> void:

--- a/addons/beehave/nodes/composites/selector_random.gd
+++ b/addons/beehave/nodes/composites/selector_random.gd
@@ -61,6 +61,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 func after_run(actor: Node, blackboard: Blackboard) -> void:
 	_reset()
+	super(actor, blackboard)
 
 
 func interrupt(actor: Node, blackboard: Blackboard) -> void:

--- a/addons/beehave/nodes/composites/sequence_random.gd
+++ b/addons/beehave/nodes/composites/sequence_random.gd
@@ -68,6 +68,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 func after_run(actor: Node, blackboard: Blackboard) -> void:
 	if not resume_on_failure:
 		_reset()
+	super(actor, blackboard)
 
 
 func interrupt(actor: Node, blackboard: Blackboard) -> void:

--- a/addons/beehave/nodes/decorators/decorator.gd
+++ b/addons/beehave/nodes/decorators/decorator.gd
@@ -31,6 +31,10 @@ func interrupt(actor: Node, blackboard: Blackboard) -> void:
 		running_child = null
 
 
+func after_run(actor: Node, blackboard: Blackboard) -> void:
+	running_child = null
+
+
 func get_class_name() -> Array[StringName]:
 	var classes := super()
 	classes.push_back(&"Decorator")

--- a/addons/beehave/nodes/decorators/time_limiter.gd
+++ b/addons/beehave/nodes/decorators/time_limiter.gd
@@ -1,0 +1,46 @@
+## The Time Limit Decorator will give its child a set amount of time to finish
+## before interrupting it and return a `FAILURE` status code. The timer is reset
+## every time before the node runs.
+@tool
+@icon("../../icons/limiter.svg")
+class_name TimeLimiterDecorator extends Decorator
+
+@export var wait_time: = 0.0
+
+var time_left: = 0.0
+
+@onready var child: BeehaveNode = get_child(0)
+
+
+func tick(actor: Node, blackboard: Blackboard) -> int:
+	if time_left < wait_time:
+		time_left += get_physics_process_delta_time()
+		var response = child.tick(actor, blackboard)
+		if can_send_message(blackboard):
+			BeehaveDebuggerMessages.process_tick(child.get_instance_id(), response)
+		
+		if child is ConditionLeaf:
+			blackboard.set_value("last_condition", child, str(actor.get_instance_id()))
+			blackboard.set_value("last_condition_status", response, str(actor.get_instance_id()))
+		
+		if response == RUNNING:
+			running_child = child
+			if child is ActionLeaf:
+				blackboard.set_value("running_action", child, str(actor.get_instance_id()))
+		
+		return response
+	else:
+		child.after_run(actor, blackboard)
+		interrupt(actor, blackboard)
+		return FAILURE
+
+
+func before_run(actor: Node, blackboard: Blackboard) -> void:
+	time_left = 0.0
+	child.before_run(actor, blackboard)
+
+
+func get_class_name() -> Array[StringName]:
+	var classes := super()
+	classes.push_back(&"TimeLimiterDecorator")
+	return classes

--- a/docs/manual/decorators.md
+++ b/docs/manual/decorators.md
@@ -20,3 +20,8 @@ An `Inverter` node reverses the outcome of its child node. It returns `FAILURE` 
 The `Limiter` node executes its child a specified number of times (x). When the maximum number of ticks is reached, it returns a `FAILURE` status code. This can be beneficial when you want to limit the number of times an action or condition is executed, such as limiting the number of attempts an NPC makes to perform a task.
 
 **Example:** An NPC tries to unlock a door with lockpicks but will give up after three attempts if unsuccessful.
+
+## TimeLimiter
+The `TimeLimiter` node only gives its child a set amount of time to finish. When the time is up, it interrupts its child and returns a `FAILURE` status code. This is useful when you want to limit the execution time of a long running action.
+
+**Example:** A mob aggros and tries to chase you, the chase action will last a maximum of 10 seconds before being aborted if not complete.

--- a/test/nodes/composites/selector_random_test.gd
+++ b/test/nodes/composites/selector_random_test.gd
@@ -8,22 +8,32 @@ extends GdUnitTestSuite
 const __source = "res://addons/beehave/nodes/composites/selector_random.gd"
 const __count_up_action = "res://test/actions/count_up_action.gd"
 const __blackboard = "res://addons/beehave/blackboard.gd"
+const __tree = "res://addons/beehave/nodes/beehave_tree.gd"
 const RANDOM_SEED = 123
 
-var selector:SelectorRandomComposite
-var action1:ActionLeaf
-var action2:ActionLeaf
-var actor:Node
-var blackboard:Blackboard
+var tree: BeehaveTree
+var selector: SelectorRandomComposite
+var action1: ActionLeaf
+var action2: ActionLeaf
+var actor: Node
+var blackboard: Blackboard
+
 
 func before_test() -> void:
+	tree = auto_free(load(__tree).new())
 	selector = auto_free(load(__source).new())
 	action1 = auto_free(load(__count_up_action).new())
-	selector.add_child(action1)
 	action2 = auto_free(load(__count_up_action).new())
-	selector.add_child(action2)
 	actor = auto_free(Node2D.new())
 	blackboard = auto_free(load(__blackboard).new())
+	
+	tree.add_child(selector)
+	selector.add_child(action1)
+	selector.add_child(action2)
+	
+	tree.actor = actor
+	tree.blackboard = blackboard
+
 
 func test_always_executing_first_successful_node() -> void:
 	selector.random_seed = RANDOM_SEED
@@ -31,7 +41,8 @@ func test_always_executing_first_successful_node() -> void:
 	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.SUCCESS)
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(1)
-	
+
+
 func test_execute_second_when_first_is_failing() -> void:
 	selector.random_seed = RANDOM_SEED
 	action1.status = BeehaveNode.FAILURE
@@ -39,14 +50,16 @@ func test_execute_second_when_first_is_failing() -> void:
 	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.SUCCESS)
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(2)
-	
+
+
 func test_random_even_execution() -> void:
 	selector.random_seed = RANDOM_SEED
 	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.SUCCESS)
 	assert_that(action1.count).is_equal(1)
 	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.SUCCESS)
 	assert_that(action2.count).is_equal(1)
-	
+
+
 func test_return_failure_of_none_is_succeeding() -> void:
 	selector.random_seed = RANDOM_SEED
 	action1.status = BeehaveNode.FAILURE
@@ -54,5 +67,13 @@ func test_return_failure_of_none_is_succeeding() -> void:
 	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.FAILURE)
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(1)
-	
-	
+
+
+func test_clear_running_child_after_run() -> void:
+	action1.status = BeehaveNode.FAILURE
+	action2.status = BeehaveNode.RUNNING
+	tree.tick()
+	assert_that(selector.running_child).is_equal(action2)
+	action2.status = BeehaveNode.FAILURE
+	tree.tick()
+	assert_that(selector.running_child).is_equal(null)

--- a/test/nodes/composites/selector_reactive_test.gd
+++ b/test/nodes/composites/selector_reactive_test.gd
@@ -12,6 +12,7 @@ const __blackboard = "res://addons/beehave/blackboard.gd"
 const __tree = "res://addons/beehave/nodes/beehave_tree.gd"
 
 var tree: BeehaveTree
+var selector: SelectorReactiveComposite
 var action1: ActionLeaf
 var action2: ActionLeaf
 
@@ -20,7 +21,7 @@ func before_test() -> void:
 	tree = auto_free(load(__tree).new())
 	action1 = auto_free(load(__count_up_action).new())
 	action2 = auto_free(load(__count_up_action).new())
-	var selector = auto_free(load(__source).new())
+	selector = auto_free(load(__source).new())
 	var actor = auto_free(Node2D.new())
 	var blackboard = auto_free(load(__blackboard).new())
 	
@@ -105,7 +106,8 @@ func test_keeps_restarting_child_until_failure() -> void:
 	assert_that(tree.tick()).is_equal(BeehaveNode.FAILURE)
 	assert_that(action1.count).is_equal(4)
 	assert_that(action2.count).is_equal(4)
-	
+
+
 func test_interrupt_second_when_first_is_running() -> void:
 	action1.status = BeehaveNode.FAILURE
 	action2.status = BeehaveNode.RUNNING
@@ -117,3 +119,13 @@ func test_interrupt_second_when_first_is_running() -> void:
 	assert_that(tree.tick()).is_equal(BeehaveNode.RUNNING)
 	assert_that(action1.count).is_equal(2)
 	assert_that(action2.count).is_equal(0)
+
+
+func test_clear_running_child_after_run() -> void:
+	action1.status = BeehaveNode.FAILURE
+	action2.status = BeehaveNode.RUNNING
+	tree.tick()
+	assert_that(selector.running_child).is_equal(action2)
+	action2.status = BeehaveNode.FAILURE
+	tree.tick()
+	assert_that(selector.running_child).is_equal(null)

--- a/test/nodes/composites/selector_test.gd
+++ b/test/nodes/composites/selector_test.gd
@@ -8,42 +8,55 @@ extends GdUnitTestSuite
 const __source = "res://addons/beehave/nodes/composites/selector.gd"
 const __count_up_action = "res://test/actions/count_up_action.gd"
 const __blackboard = "res://addons/beehave/blackboard.gd"
+const __tree = "res://addons/beehave/nodes/beehave_tree.gd"
 
-var selector:SelectorComposite
-var action1:ActionLeaf
-var action2:ActionLeaf
-var actor:Node
-var blackboard:Blackboard
+var tree: BeehaveTree
+var selector: SelectorComposite
+var action1: ActionLeaf
+var action2: ActionLeaf
+var actor: Node
+var blackboard: Blackboard
+
 
 func before_test() -> void:
+	tree = auto_free(load(__tree).new())
 	selector = auto_free(load(__source).new())
 	action1 = auto_free(load(__count_up_action).new())
-	selector.add_child(action1)
 	action2 = auto_free(load(__count_up_action).new())
-	selector.add_child(action2)
 	actor = auto_free(Node2D.new())
 	blackboard = auto_free(load(__blackboard).new())
+	
+	tree.add_child(selector)
+	selector.add_child(action1)
+	selector.add_child(action2)
+	
+	tree.actor = actor
+	tree.blackboard = blackboard
+
 
 func test_always_executing_first_successful_node() -> void:
 	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.SUCCESS)
 	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.SUCCESS)
 	assert_that(action1.count).is_equal(2)
 	assert_that(action2.count).is_equal(0)
-	
+
+
 func test_execute_second_when_first_is_failing() -> void:
 	action1.status = BeehaveNode.FAILURE
 	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.SUCCESS)
 	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.SUCCESS)
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(2)
-	
+
+
 func test_return_failure_of_none_is_succeeding() -> void:
 	action1.status = BeehaveNode.FAILURE
 	action2.status = BeehaveNode.FAILURE
 	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.FAILURE)
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(1)
-	
+
+
 func test_not_interrupt_second_when_first_is_succeeding() -> void:
 	action1.status = BeehaveNode.FAILURE
 	action2.status = BeehaveNode.RUNNING
@@ -56,6 +69,7 @@ func test_not_interrupt_second_when_first_is_succeeding() -> void:
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(2)
 
+
 func test_not_interrupt_second_when_first_is_running() -> void:
 	action1.status = BeehaveNode.FAILURE
 	action2.status = BeehaveNode.RUNNING
@@ -67,7 +81,7 @@ func test_not_interrupt_second_when_first_is_running() -> void:
 	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.RUNNING)
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(2)
-	
+
 
 func test_tick_again_when_child_returns_running() -> void:
 	action1.status = BeehaveNode.FAILURE
@@ -76,3 +90,13 @@ func test_tick_again_when_child_returns_running() -> void:
 	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.RUNNING)
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(2)
+
+
+func test_clear_running_child_after_run() -> void:
+	action1.status = BeehaveNode.FAILURE
+	action2.status = BeehaveNode.RUNNING
+	tree.tick()
+	assert_that(selector.running_child).is_equal(action2)
+	action2.status = BeehaveNode.FAILURE
+	tree.tick()
+	assert_that(selector.running_child).is_equal(null)

--- a/test/nodes/composites/sequence_random_test.gd
+++ b/test/nodes/composites/sequence_random_test.gd
@@ -13,6 +13,7 @@ const __tree = "res://addons/beehave/nodes/beehave_tree.gd"
 const RANDOM_SEED = 123
 
 var tree: BeehaveTree
+var sequence: SequenceRandomComposite
 var action1: ActionLeaf
 var action2: ActionLeaf
 
@@ -21,7 +22,7 @@ func before_test() -> void:
 	tree = auto_free(load(__tree).new())
 	action1 = auto_free(load(__count_up_action).new())
 	action2 = auto_free(load(__count_up_action).new())
-	var sequence = auto_free(load(__source).new())
+	sequence = auto_free(load(__source).new())
 	sequence.random_seed = RANDOM_SEED
 	var actor = auto_free(Node2D.new())
 	var blackboard = auto_free(load(__blackboard).new())
@@ -70,3 +71,13 @@ func test_return_failure_of_none_is_succeeding() -> void:
 	
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(0)
+
+
+func test_clear_running_child_after_run() -> void:
+	action1.status = BeehaveNode.SUCCESS
+	action2.status = BeehaveNode.RUNNING
+	tree.tick()
+	assert_that(sequence.running_child).is_equal(action2)
+	action2.status = BeehaveNode.SUCCESS
+	tree.tick()
+	assert_that(sequence.running_child).is_equal(null)

--- a/test/nodes/composites/sequence_reactive_test.gd
+++ b/test/nodes/composites/sequence_reactive_test.gd
@@ -124,3 +124,13 @@ func test_interrupt_second_when_first_is_running() -> void:
 	assert_that(tree.tick()).is_equal(BeehaveNode.RUNNING)
 	assert_that(action1.count).is_equal(2)
 	assert_that(action2.count).is_equal(0)
+
+
+func test_clear_running_child_after_run() -> void:
+	action1.status = BeehaveNode.SUCCESS
+	action2.status = BeehaveNode.RUNNING
+	tree.tick()
+	assert_that(sequence.running_child).is_equal(action2)
+	action2.status = BeehaveNode.SUCCESS
+	tree.tick()
+	assert_that(sequence.running_child).is_equal(null)

--- a/test/nodes/composites/sequence_star_test.gd
+++ b/test/nodes/composites/sequence_star_test.gd
@@ -18,6 +18,7 @@ var actor: Node
 var blackboard: Blackboard
 var sequence: SequenceStarComposite
 
+
 func before_test() -> void:
 	tree = auto_free(load(__tree).new())
 	action1 = auto_free(load(__count_up_action).new())
@@ -96,6 +97,7 @@ func test_keeps_running_child_until_failure() -> void:
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(4)
 
+
 func test_tick_again_when_child_returns_failure() -> void:
 	action1.status = BeehaveNode.SUCCESS
 	action2.status = BeehaveNode.FAILURE
@@ -103,7 +105,8 @@ func test_tick_again_when_child_returns_failure() -> void:
 	assert_that(sequence.tick(actor, blackboard)).is_equal(BeehaveNode.FAILURE)
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(2)
-	
+
+
 func test_tick_again_when_child_returns_running() -> void:
 	action1.status = BeehaveNode.SUCCESS
 	action2.status = BeehaveNode.RUNNING
@@ -111,3 +114,13 @@ func test_tick_again_when_child_returns_running() -> void:
 	assert_that(sequence.tick(actor, blackboard)).is_equal(BeehaveNode.RUNNING)
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(2)
+
+
+func test_clear_running_child_after_run() -> void:
+	action1.status = BeehaveNode.SUCCESS
+	action2.status = BeehaveNode.RUNNING
+	tree.tick()
+	assert_that(sequence.running_child).is_equal(action2)
+	action2.status = BeehaveNode.SUCCESS
+	tree.tick()
+	assert_that(sequence.running_child).is_equal(null)

--- a/test/nodes/composites/sequence_test.gd
+++ b/test/nodes/composites/sequence_test.gd
@@ -8,35 +8,47 @@ extends GdUnitTestSuite
 const __source = "res://addons/beehave/nodes/composites/sequence.gd"
 const __count_up_action = "res://test/actions/count_up_action.gd"
 const __blackboard = "res://addons/beehave/blackboard.gd"
+const __tree = "res://addons/beehave/nodes/beehave_tree.gd"
 
+var tree: BeehaveTree
 var sequence: SequenceComposite
 var action1: ActionLeaf
 var action2: ActionLeaf
 var actor: Node
 var blackboard: Blackboard
 
+
 func before_test() -> void:
+	tree = auto_free(load(__tree).new())
 	sequence = auto_free(load(__source).new())
 	action1 = auto_free(load(__count_up_action).new())
-	sequence.add_child(action1)
 	action2 = auto_free(load(__count_up_action).new())
-	sequence.add_child(action2)
 	actor = auto_free(Node2D.new())
 	blackboard = auto_free(load(__blackboard).new())
+	
+	tree.add_child(sequence)
+	sequence.add_child(action1)
+	sequence.add_child(action2)
+	
+	tree.actor = actor
+	tree.blackboard = blackboard
+
 
 func test_always_executing_all_successful_nodes() -> void:
 	assert_that(sequence.tick(actor, blackboard)).is_equal(BeehaveNode.SUCCESS)
 	assert_that(sequence.tick(actor, blackboard)).is_equal(BeehaveNode.SUCCESS)
 	assert_that(action1.count).is_equal(2)
 	assert_that(action2.count).is_equal(2)
-	
+
+
 func test_never_execute_second_when_first_is_failing() -> void:
 	action1.status = BeehaveNode.FAILURE
 	assert_that(sequence.tick(actor, blackboard)).is_equal(BeehaveNode.FAILURE)
 	assert_that(sequence.tick(actor, blackboard)).is_equal(BeehaveNode.FAILURE)
 	assert_that(action1.count).is_equal(2)
 	assert_that(action2.count).is_equal(0)
-	
+
+
 func test_not_interrupt_second_when_first_is_failing() -> void:
 	action1.status = BeehaveNode.SUCCESS
 	action2.status = BeehaveNode.RUNNING
@@ -49,6 +61,7 @@ func test_not_interrupt_second_when_first_is_failing() -> void:
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(2)
 
+
 func test_not_interrupting_second_when_first_is_running() -> void:
 	action1.status = BeehaveNode.SUCCESS
 	action2.status = BeehaveNode.RUNNING
@@ -60,7 +73,8 @@ func test_not_interrupting_second_when_first_is_running() -> void:
 	assert_that(sequence.tick(actor, blackboard)).is_equal(BeehaveNode.RUNNING)
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(2)
-	
+
+
 func test_restart_when_child_returns_failure() -> void:
 	action1.status = BeehaveNode.SUCCESS
 	action2.status = BeehaveNode.FAILURE
@@ -76,3 +90,13 @@ func test_tick_again_when_child_returns_running() -> void:
 	assert_that(sequence.tick(actor, blackboard)).is_equal(BeehaveNode.RUNNING)
 	assert_that(action1.count).is_equal(1)
 	assert_that(action2.count).is_equal(2)
+
+
+func test_clear_running_child_after_run() -> void:
+	action1.status = BeehaveNode.SUCCESS
+	action2.status = BeehaveNode.RUNNING
+	tree.tick()
+	assert_that(sequence.running_child).is_equal(action2)
+	action2.status = BeehaveNode.SUCCESS
+	tree.tick()
+	assert_that(sequence.running_child).is_equal(null)

--- a/test/nodes/decorators/failer_test.gd
+++ b/test/nodes/decorators/failer_test.gd
@@ -12,12 +12,13 @@ const __blackboard = "res://addons/beehave/blackboard.gd"
 
 var tree: BeehaveTree
 var action: ActionLeaf
+var failer: AlwaysFailDecorator
 
 
 func before_test() -> void:
 	tree = auto_free(load(__tree).new())
 	action = auto_free(load(__action).new())
-	var failer = auto_free(load(__source).new())
+	failer = auto_free(load(__source).new())
 	
 	var actor = auto_free(Node2D.new())
 	var blackboard = auto_free(load(__blackboard).new())
@@ -32,3 +33,12 @@ func before_test() -> void:
 func test_tick() -> void:
 	action.status = BeehaveNode.SUCCESS
 	assert_that(tree.tick()).is_equal(BeehaveNode.FAILURE)
+
+
+func test_clear_running_child_after_run() -> void:
+	action.status = BeehaveNode.RUNNING
+	tree.tick()
+	assert_that(failer.running_child).is_equal(action)
+	action.status = BeehaveNode.SUCCESS
+	tree.tick()
+	assert_that(failer.running_child).is_equal(null)

--- a/test/nodes/decorators/limiter_test.gd
+++ b/test/nodes/decorators/limiter_test.gd
@@ -37,3 +37,13 @@ func test_max_count(count: int, test_parameters: Array = [[2], [0]]) -> void:
 		assert_that(tree.tick()).is_equal(BeehaveNode.SUCCESS)
 
 	assert_that(tree.tick()).is_equal(BeehaveNode.FAILURE)
+
+
+func test_clear_running_child_after_run() -> void:
+	action.status = BeehaveNode.RUNNING
+	limiter.max_count = 10
+	tree.tick()
+	assert_that(limiter.running_child).is_equal(action)
+	action.status = BeehaveNode.SUCCESS
+	tree.tick()
+	assert_that(limiter.running_child).is_equal(null)

--- a/test/nodes/decorators/succeeder_test.gd
+++ b/test/nodes/decorators/succeeder_test.gd
@@ -12,12 +12,13 @@ const __blackboard = "res://addons/beehave/blackboard.gd"
 
 var tree: BeehaveTree
 var action: ActionLeaf
+var succeeder: AlwaysSucceedDecorator
 
 
 func before_test() -> void:
 	tree = auto_free(load(__tree).new())
 	action = auto_free(load(__action).new())
-	var succeeder = auto_free(load(__source).new())
+	succeeder = auto_free(load(__source).new())
 	
 	var actor = auto_free(Node2D.new())
 	var blackboard = auto_free(load(__blackboard).new())
@@ -32,3 +33,12 @@ func before_test() -> void:
 func test_tick() -> void:
 	action.status = BeehaveNode.FAILURE
 	assert_that(tree.tick()).is_equal(BeehaveNode.SUCCESS)
+
+
+func test_clear_running_child_after_run() -> void:
+	action.status = BeehaveNode.RUNNING
+	tree.tick()
+	assert_that(succeeder.running_child).is_equal(action)
+	action.status = BeehaveNode.SUCCESS
+	tree.tick()
+	assert_that(succeeder.running_child).is_equal(null)

--- a/test/nodes/decorators/time_limiter_test.gd
+++ b/test/nodes/decorators/time_limiter_test.gd
@@ -1,50 +1,59 @@
 # GdUnit generated TestSuite
-class_name InverterTest
+class_name TimeLimitTest
 extends GdUnitTestSuite
 @warning_ignore("unused_parameter")
 @warning_ignore("return_value_discarded")
 
-
 # TestSuite generated from
-const __source = "res://addons/beehave/nodes/decorators/inverter.gd"
+const __source = "res://addons/beehave/nodes/decorators/time_limit.gd"
 const __action = "res://test/actions/count_up_action.gd"
 const __tree = "res://addons/beehave/nodes/beehave_tree.gd"
 const __blackboard = "res://addons/beehave/blackboard.gd"
 
 var tree: BeehaveTree
 var action: ActionLeaf
-var inverter: InverterDecorator
+var time_limit: TimeLimitDecorator
 
 
 func before_test() -> void:
 	tree = auto_free(load(__tree).new())
 	action = auto_free(load(__action).new())
-	inverter = auto_free(load(__source).new())
+	time_limit = auto_free(load(__source).new())
 	
 	var actor = auto_free(Node2D.new())
 	var blackboard = auto_free(load(__blackboard).new())
 	
-	tree.add_child(inverter)
-	inverter.add_child(action)
+	tree.add_child(time_limit)
+	time_limit.child = action
 	
 	tree.actor = actor
 	tree.blackboard = blackboard
 
 
-func test_invert_success_to_failure() -> void:
-	action.status = BeehaveNode.SUCCESS
+func test_return_failure_when_child_exceeds_time_limit() -> void:
+	time_limit.wait_time = 1.0
+	action.status = BeehaveNode.RUNNING
+	assert_that(tree.tick()).is_equal(BeehaveNode.RUNNING)
+	time_limit.time_left = 0.5
+	assert_that(tree.tick()).is_equal(BeehaveNode.RUNNING)
+	time_limit.time_left = 1.0
 	assert_that(tree.tick()).is_equal(BeehaveNode.FAILURE)
 
 
-func test_invert_failure_to_success() -> void:
-	action.status = BeehaveNode.FAILURE
+func test_reset_when_child_finishes() -> void:
+	time_limit.wait_time = 1.0
+	action.status = BeehaveNode.RUNNING
+	assert_that(tree.tick()).is_equal(BeehaveNode.RUNNING)
+	time_limit.time_left = 0.5
+	action.status = BeehaveNode.SUCCESS
 	assert_that(tree.tick()).is_equal(BeehaveNode.SUCCESS)
 
 
 func test_clear_running_child_after_run() -> void:
+	time_limit.wait_time = 1.0
 	action.status = BeehaveNode.RUNNING
 	tree.tick()
-	assert_that(inverter.running_child).is_equal(action)
+	assert_that(time_limit.running_child).is_equal(action)
 	action.status = BeehaveNode.SUCCESS
 	tree.tick()
-	assert_that(inverter.running_child).is_equal(null)
+	assert_that(time_limit.running_child).is_equal(null)

--- a/test/nodes/decorators/time_limiter_test.gd
+++ b/test/nodes/decorators/time_limiter_test.gd
@@ -5,55 +5,55 @@ extends GdUnitTestSuite
 @warning_ignore("return_value_discarded")
 
 # TestSuite generated from
-const __source = "res://addons/beehave/nodes/decorators/time_limit.gd"
+const __source = "res://addons/beehave/nodes/decorators/time_limiter.gd"
 const __action = "res://test/actions/count_up_action.gd"
 const __tree = "res://addons/beehave/nodes/beehave_tree.gd"
 const __blackboard = "res://addons/beehave/blackboard.gd"
 
 var tree: BeehaveTree
 var action: ActionLeaf
-var time_limit: TimeLimitDecorator
+var time_limiter: TimeLimiterDecorator
 
 
 func before_test() -> void:
 	tree = auto_free(load(__tree).new())
 	action = auto_free(load(__action).new())
-	time_limit = auto_free(load(__source).new())
+	time_limiter = auto_free(load(__source).new())
 	
 	var actor = auto_free(Node2D.new())
 	var blackboard = auto_free(load(__blackboard).new())
 	
-	tree.add_child(time_limit)
-	time_limit.child = action
+	tree.add_child(time_limiter)
+	time_limiter.child = action
 	
 	tree.actor = actor
 	tree.blackboard = blackboard
 
 
-func test_return_failure_when_child_exceeds_time_limit() -> void:
-	time_limit.wait_time = 1.0
+func test_return_failure_when_child_exceeds_time_limiter() -> void:
+	time_limiter.wait_time = 1.0
 	action.status = BeehaveNode.RUNNING
 	assert_that(tree.tick()).is_equal(BeehaveNode.RUNNING)
-	time_limit.time_left = 0.5
+	time_limiter.time_left = 0.5
 	assert_that(tree.tick()).is_equal(BeehaveNode.RUNNING)
-	time_limit.time_left = 1.0
+	time_limiter.time_left = 1.0
 	assert_that(tree.tick()).is_equal(BeehaveNode.FAILURE)
 
 
 func test_reset_when_child_finishes() -> void:
-	time_limit.wait_time = 1.0
+	time_limiter.wait_time = 1.0
 	action.status = BeehaveNode.RUNNING
 	assert_that(tree.tick()).is_equal(BeehaveNode.RUNNING)
-	time_limit.time_left = 0.5
+	time_limiter.time_left = 0.5
 	action.status = BeehaveNode.SUCCESS
 	assert_that(tree.tick()).is_equal(BeehaveNode.SUCCESS)
 
 
 func test_clear_running_child_after_run() -> void:
-	time_limit.wait_time = 1.0
+	time_limiter.wait_time = 1.0
 	action.status = BeehaveNode.RUNNING
 	tree.tick()
-	assert_that(time_limit.running_child).is_equal(action)
+	assert_that(time_limiter.running_child).is_equal(action)
 	action.status = BeehaveNode.SUCCESS
 	tree.tick()
-	assert_that(time_limit.running_child).is_equal(null)
+	assert_that(time_limiter.running_child).is_equal(null)


### PR DESCRIPTION
## Description

- Add TimeLimiter node that will fails the child that does not finish running after x seconds specified in export variable `wait_time`.
- Clear running child of decorators and composite nodes after ran.
- `BeehaveRoot` now call child's `before_run` if it was not running in previous tick. 

## Screenshots

![image](https://github.com/bitbrain/beehave/assets/66206021/8944b73d-ad8d-4d42-b78e-300de4ca187b)

Player entering an Enemy range will be chased for a set amount of time, it will then lose aggro if Chase action can not finish in time.
