### PR TITLE
Do not interrupt action after it finishes

### DIFF
--- a/addons/beehave/nodes/composites/selector.gd
+++ b/addons/beehave/nodes/composites/selector.gd
@@ -6,6 +6,7 @@
 @icon("../../icons/selector.svg")
 class_name SelectorComposite extends Composite
 
+
 var last_execution_index: int = 0
 
 
@@ -27,9 +28,11 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 		match response:
 			SUCCESS:
+				_cleanup_running_task(c, actor, blackboard)
 				c.after_run(actor, blackboard)
 				return SUCCESS
 			FAILURE:
+				_cleanup_running_task(c, actor, blackboard)
 				last_execution_index += 1
 				c.after_run(actor, blackboard)
 			RUNNING:
@@ -49,6 +52,15 @@ func after_run(actor: Node, blackboard: Blackboard) -> void:
 func interrupt(actor: Node, blackboard: Blackboard) -> void:
 	after_run(actor, blackboard)
 	super(actor, blackboard)
+
+
+## Changes `running_action` and `running_child` after the node finishes executing.
+func _cleanup_running_task(finished_action: Node, actor: Node, blackboard: Blackboard):
+	var blackboard_name = str(actor.get_instance_id())
+	if finished_action == running_child:
+		running_child = null
+		if finished_action == blackboard.get_value("running_action", null, blackboard_name):
+			blackboard.set_value("running_action", null, blackboard_name)
 
 
 func get_class_name() -> Array[StringName]:

--- a/addons/beehave/nodes/composites/sequence.gd
+++ b/addons/beehave/nodes/composites/sequence.gd
@@ -31,12 +31,10 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		match response:
 			SUCCESS:
 				_cleanup_running_task(c, actor, blackboard)
-
 				successful_index += 1
 				c.after_run(actor, blackboard)
 			FAILURE:
 				_cleanup_running_task(c, actor, blackboard)
-
 				# Interrupt any child that was RUNNING before.
 				interrupt(actor, blackboard)
 				c.after_run(actor, blackboard)

--- a/addons/beehave/nodes/composites/sequence.gd
+++ b/addons/beehave/nodes/composites/sequence.gd
@@ -30,9 +30,13 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 		match response:
 			SUCCESS:
+				_cleanup_running_task(c, actor, blackboard)
+
 				successful_index += 1
 				c.after_run(actor, blackboard)
 			FAILURE:
+				_cleanup_running_task(c, actor, blackboard)
+
 				# Interrupt any child that was RUNNING before.
 				interrupt(actor, blackboard)
 				c.after_run(actor, blackboard)
@@ -53,9 +57,19 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 func interrupt(actor: Node, blackboard: Blackboard) -> void:
 	_reset()
 	super(actor, blackboard)
-	
+
+
 func _reset() -> void:
 	successful_index = 0
+
+
+## Changes `running_action` and `running_child` after the node finishes executing.
+func _cleanup_running_task(finished_action: Node, actor: Node, blackboard: Blackboard):
+	var blackboard_name = str(actor.get_instance_id())
+	if finished_action == running_child:
+		running_child = null
+		if finished_action == blackboard.get_value("running_action", null, blackboard_name):
+			blackboard.set_value("running_action", null, blackboard_name)
 
 
 func get_class_name() -> Array[StringName]:

--- a/test/nodes/composites/selector_test.gd
+++ b/test/nodes/composites/selector_test.gd
@@ -100,3 +100,28 @@ func test_clear_running_child_after_run() -> void:
 	action2.status = BeehaveNode.FAILURE
 	tree.tick()
 	assert_that(selector.running_child).is_equal(null)
+
+
+func test_not_interrupt_first_after_finished() -> void:
+	var action3 = auto_free(load(__count_up_action).new())
+	selector.add_child(action3)
+	var running_action: Node
+	var blackboard_name: String = str(actor.get_instance_id())
+
+	action1.status = BeehaveNode.RUNNING
+	action2.status = BeehaveNode.FAILURE
+	action3.status = BeehaveNode.RUNNING
+
+	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.RUNNING)
+	assert_that(action1.count).is_equal(1)
+	assert_that(action2.count).is_equal(0)
+	assert_that(action3.count).is_equal(0)
+	
+	action1.status = BeehaveNode.FAILURE
+	assert_that(selector.tick(actor, blackboard)).is_equal(BeehaveNode.RUNNING)
+	assert_that(action1.count).is_equal(2)
+	assert_that(action2.count).is_equal(1)
+	assert_that(action3.count).is_equal(1)
+	
+	selector.remove_child(action3)
+

--- a/test/nodes/composites/sequence_test.gd
+++ b/test/nodes/composites/sequence_test.gd
@@ -100,3 +100,25 @@ func test_clear_running_child_after_run() -> void:
 	action2.status = BeehaveNode.SUCCESS
 	tree.tick()
 	assert_that(sequence.running_child).is_equal(null)
+
+
+func test_not_interrupt_first_after_finished() -> void:
+	var action3 = auto_free(load(__count_up_action).new())
+	sequence.add_child(action3)
+
+	action1.status = BeehaveNode.RUNNING
+	action2.status = BeehaveNode.SUCCESS
+	action3.status = BeehaveNode.RUNNING
+
+	assert_that(sequence.tick(actor, blackboard)).is_equal(BeehaveNode.RUNNING)
+	assert_that(action1.count).is_equal(1)
+	assert_that(action2.count).is_equal(0)
+	assert_that(action3.count).is_equal(0)
+	
+	action1.status = BeehaveNode.SUCCESS
+	assert_that(sequence.tick(actor, blackboard)).is_equal(BeehaveNode.RUNNING)
+	assert_that(action1.count).is_equal(2)
+	assert_that(action2.count).is_equal(1)
+	assert_that(action3.count).is_equal(1)
+	
+	sequence.remove_child(action3)


### PR DESCRIPTION
## Description

Whenever a child returns `SUCCESS` or `FAILURE` we check if the child is the running_action or the running_child to set them to null. I did the same with the selector node however I could not find a case where selector would interrupt a child incorrectly (only found a case in sequence). 

## Addressed issues
Closes #211 
