### PR TITLE
Fix compile errors for 4.2 dev5 change of get_zoom_hbox() to get_menu_hbox()

### DIFF
--- a/addons/beehave/debug/debugger_tab.gd
+++ b/addons/beehave/debug/debugger_tab.gd
@@ -41,7 +41,7 @@ func _ready() -> void:
 	button.pressed.connect(func(): make_floating.emit())
 	button.tooltip_text = "Make floating"
 	button.focus_mode = Control.FOCUS_NONE
-	graph.get_zoom_hbox().add_child(button)
+	graph.get_menu_hbox().add_child(button)
 
 	var toggle_button := Button.new()
 	toggle_button.flat = true
@@ -49,8 +49,8 @@ func _ready() -> void:
 	toggle_button.pressed.connect(_on_toggle_button_pressed.bind(toggle_button))
 	toggle_button.tooltip_text = "Toggle Panel"
 	toggle_button.focus_mode = Control.FOCUS_NONE
-	graph.get_zoom_hbox().add_child(toggle_button)
-	graph.get_zoom_hbox().move_child(toggle_button, 0)
+	graph.get_menu_hbox().add_child(toggle_button)
+	graph.get_menu_hbox().move_child(toggle_button, 0)
 
 	stop()
 	visibility_changed.connect(_on_visibility_changed)

--- a/addons/beehave/debug/debugger_tab.gd
+++ b/addons/beehave/debug/debugger_tab.gd
@@ -41,7 +41,7 @@ func _ready() -> void:
 	button.pressed.connect(func(): make_floating.emit())
 	button.tooltip_text = "Make floating"
 	button.focus_mode = Control.FOCUS_NONE
-	graph.get_menu_hbox().add_child(button)
+        get_box().add_child(button)
 
 	var toggle_button := Button.new()
 	toggle_button.flat = true

--- a/addons/beehave/debug/debugger_tab.gd
+++ b/addons/beehave/debug/debugger_tab.gd
@@ -49,7 +49,7 @@ func _ready() -> void:
 	toggle_button.pressed.connect(_on_toggle_button_pressed.bind(toggle_button))
 	toggle_button.tooltip_text = "Toggle Panel"
 	toggle_button.focus_mode = Control.FOCUS_NONE
-	graph.get_menu_hbox().add_child(toggle_button)
+	get_box().add_child(toggle_button)
 	graph.get_menu_hbox().move_child(toggle_button, 0)
 
 	stop()

--- a/addons/beehave/debug/debugger_tab.gd
+++ b/addons/beehave/debug/debugger_tab.gd
@@ -50,7 +50,7 @@ func _ready() -> void:
 	toggle_button.tooltip_text = "Toggle Panel"
 	toggle_button.focus_mode = Control.FOCUS_NONE
 	get_box().add_child(toggle_button)
-	graph.get_menu_hbox().move_child(toggle_button, 0)
+	get_box().move_child(toggle_button, 0)
 
 	stop()
 	visibility_changed.connect(_on_visibility_changed)

--- a/addons/beehave/debug/graph_edit.gd
+++ b/addons/beehave/debug/graph_edit.gd
@@ -47,7 +47,7 @@ func _ready() -> void:
 	layout_button.flat = true
 	layout_button.focus_mode = Control.FOCUS_NONE
 	layout_button.pressed.connect(func(): horizontal_layout = not horizontal_layout)
-	get_menu_hbox().add_child(layout_button)
+	get_box().add_child(layout_button)
 	_update_layout_button()
 
 

--- a/addons/beehave/debug/graph_edit.gd
+++ b/addons/beehave/debug/graph_edit.gd
@@ -47,7 +47,7 @@ func _ready() -> void:
 	layout_button.flat = true
 	layout_button.focus_mode = Control.FOCUS_NONE
 	layout_button.pressed.connect(func(): horizontal_layout = not horizontal_layout)
-	get_zoom_hbox().add_child(layout_button)
+	get_menu_hbox().add_child(layout_button)
 	_update_layout_button()
 
 


### PR DESCRIPTION
## Description

Beehave fails to compile due to 4.2 dev 5 change of get_zoom_hbox() to get_menu_hbox()

## Addressed issues

Closes #219 
