### PR TITLE
Fix godot 4.2-dev6 compatibility issues

### DIFF
--- a/addons/beehave/debug/debugger_tab.gd
+++ b/addons/beehave/debug/debugger_tab.gd
@@ -41,7 +41,7 @@ func _ready() -> void:
 	button.pressed.connect(func(): make_floating.emit())
 	button.tooltip_text = "Make floating"
 	button.focus_mode = Control.FOCUS_NONE
-	graph.get_zoom_hbox().add_child(button)
+	graph.get_menu_container().add_child(button)
 
 	var toggle_button := Button.new()
 	toggle_button.flat = true
@@ -49,8 +49,8 @@ func _ready() -> void:
 	toggle_button.pressed.connect(_on_toggle_button_pressed.bind(toggle_button))
 	toggle_button.tooltip_text = "Toggle Panel"
 	toggle_button.focus_mode = Control.FOCUS_NONE
-	graph.get_zoom_hbox().add_child(toggle_button)
-	graph.get_zoom_hbox().move_child(toggle_button, 0)
+	graph.get_menu_container().add_child(toggle_button)
+	graph.get_menu_container().move_child(toggle_button, 0)
 
 	stop()
 	visibility_changed.connect(_on_visibility_changed)

--- a/addons/beehave/debug/graph_edit.gd
+++ b/addons/beehave/debug/graph_edit.gd
@@ -237,15 +237,40 @@ func _draw() -> void:
 
 	var connections := get_connection_list()
 	for c in connections:
-		if not c.from_node in active_nodes or not c.to_node in active_nodes:
+		var from_node: StringName
+		var to_node: StringName
+
+		# Godot 4.0+
+		if c.has("from"):
+			from_node = c.from
+			to_node = c.to
+		# Godot 4.1+
+		else:
+			from_node = c.from_node
+			to_node = c.to_node
+
+		if not from_node in active_nodes or not c.to_node in active_nodes:
 			continue
-		var from := get_node(String(c.from_node))
-		var to := get_node(String(c.to_node))
+
+		var from := get_node(String(from_node))
+		var to := get_node(String(to_node))
 
 		if from.get_meta("status", -1) < 0 or to.get_meta("status", -1) < 0:
 			return
 
-		var line := _get_connection_line(from.position + from.get_output_port_position(c.from_port), to.position + to.get_input_port_position(c.to_port))
+		var output_port_position: Vector2
+		var input_port_position: Vector2
+
+		# Godot 4.0+
+		if from.has_method("get_connection_output_position"):
+			output_port_position = from.position + from.call("get_connection_output_position", c.from_port)
+			input_port_position = to.position + to.call("get_connection_input_position", c.to_port)
+		# Godot 4.1+
+		else:
+			output_port_position = from.position + from.call("get_output_port_position", c.from_port)
+			input_port_position = to.position + to.call("get_input_port_position", c.to_port)
+
+		var line := _get_connection_line(output_port_position, input_port_position)
 
 		var curve = Curve2D.new()
 		for l in line:

--- a/examples/random_tree_example/RandomTree.gd
+++ b/examples/random_tree_example/RandomTree.gd
@@ -39,8 +39,8 @@ func _make_random_tree():
 func _parse_tree_node(parent, node, index: int):
   var n
   if node.children.size() > 1:
-    n = SelectorStarComposite.new()
-    n.name = "SelectorStarComposite%s-%d" % [get_name_suffix(), index]
+    n = SelectorReactiveComposite.new()
+    n.name = "SelectorReactiveComposite%s-%d" % [get_name_suffix(), index]
   elif node.children.size() == 1:
     n = InverterDecorator.new()
     n.name = "InverterDecorator%s-%d" % [get_name_suffix(), index]

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Beehave"
 run/main_scene="res://examples/BeehaveTestScene.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 boot_splash/image="res://splash.png"
 boot_splash/fullsize=false
 config/icon="res://icon.png"


### PR DESCRIPTION
## Description

This PR deals with the breaking changes introduced in 4.2 on the `GraphEdit` API in a way that is backwards compatible.

* I'm seeing some errors regarding GDUnit which I'm guessing will get resolved once GDUnit supports 4.2.
* Introduces the **minimum** required changes for Beehave debugger to be able to run on 4.2-dev6
* Changes the example scene to use `SelectorReactiveComposite` since `SelectorStarComposite` doesn't exist anymore
* Does not address rendering issues with the debugger (see attached screenshot) 

## Addressed issues

- Editor crash when opening the debugger
- Fix issue with reference to non-existent global class `SelectorStarComposite`

## Screenshots
<img width="1020" alt="Screenshot 2023-10-04 at 11 11 56" src="https://github.com/bitbrain/beehave/assets/1808674/df5ea028-44ca-45fe-92a0-5b7425e9d8f5">


Solves #219 
