### PR TITLE
Move Class Descriptions Below Class Names

### DIFF
--- a/addons/beehave/blackboard.gd
+++ b/addons/beehave/blackboard.gd
@@ -1,7 +1,8 @@
-## The blackboard is an object that can be used to store and access data between
-## multiple nodes of the behavior tree.
 @icon("icons/blackboard.svg")
 class_name Blackboard extends Node
+
+## The blackboard is an object that can be used to store and access data between
+## multiple nodes of the behavior tree.
 
 var blackboard: Dictionary = {}
 

--- a/addons/beehave/nodes/beehave_node.gd
+++ b/addons/beehave/nodes/beehave_node.gd
@@ -1,7 +1,8 @@
-## A node in the behavior tree. Every node must return `SUCCESS`, `FAILURE` or
-## `RUNNING` when ticked.
 @tool
 class_name BeehaveNode extends Node
+
+## A node in the behavior tree. Every node must return `SUCCESS`, `FAILURE` or
+## `RUNNING` when ticked.
 
 enum {
 	SUCCESS,

--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -1,7 +1,8 @@
-## Controls the flow of execution of the entire behavior tree.
 @tool
 @icon("../icons/tree.svg")
 class_name BeehaveTree extends Node
+
+## Controls the flow of execution of the entire behavior tree.
 
 enum {
 	SUCCESS,

--- a/addons/beehave/nodes/composites/composite.gd
+++ b/addons/beehave/nodes/composites/composite.gd
@@ -1,8 +1,8 @@
-## A Composite node controls the flow of execution of its children in a specific manner.
 @tool
 @icon("../../icons/category_composite.svg")
 class_name Composite extends BeehaveNode
 
+## A Composite node controls the flow of execution of its children in a specific manner.
 
 var running_child: BeehaveNode = null
 

--- a/addons/beehave/nodes/composites/selector.gd
+++ b/addons/beehave/nodes/composites/selector.gd
@@ -1,11 +1,11 @@
-## Selector nodes will attempt to execute each of its children until one of
-## them return `SUCCESS`. If all children return `FAILURE`, this node will also
-## return `FAILURE`.
-## If a child returns `RUNNING` it will tick again.
 @tool
 @icon("../../icons/selector.svg")
 class_name SelectorComposite extends Composite
 
+## Selector nodes will attempt to execute each of its children until one of
+## them return `SUCCESS`. If all children return `FAILURE`, this node will also
+## return `FAILURE`.
+## If a child returns `RUNNING` it will tick again.
 
 var last_execution_index: int = 0
 

--- a/addons/beehave/nodes/composites/selector_random.gd
+++ b/addons/beehave/nodes/composites/selector_random.gd
@@ -1,9 +1,10 @@
-## This node will attempt to execute all of its children just like a
-## [code]SelectorStar[/code] would, with the exception that the children
-## will be executed in a random order.
 @tool
 @icon("../../icons/selector_random.svg")
 class_name SelectorRandomComposite extends RandomizedComposite
+
+## This node will attempt to execute all of its children just like a
+## [code]SelectorStar[/code] would, with the exception that the children
+## will be executed in a random order.
 
 ## A shuffled list of the children that will be executed in reverse order.
 var _children_bag: Array[Node] = []

--- a/addons/beehave/nodes/composites/selector_reactive.gd
+++ b/addons/beehave/nodes/composites/selector_reactive.gd
@@ -1,10 +1,11 @@
+@tool
+@icon("../../icons/selector_reactive.svg")
+class_name SelectorReactiveComposite extends Composite
+
 ## Selector Reactive nodes will attempt to execute each of its children until one of
 ## them return `SUCCESS`. If all children return `FAILURE`, this node will also
 ## return `FAILURE`.
 ## If a child returns `RUNNING` it will restart.
-@tool
-@icon("../../icons/selector_reactive.svg")
-class_name SelectorReactiveComposite extends Composite
 
 func tick(actor: Node, blackboard: Blackboard) -> int:
 	for c in get_children():

--- a/addons/beehave/nodes/composites/sequence.gd
+++ b/addons/beehave/nodes/composites/sequence.gd
@@ -1,12 +1,12 @@
-## Sequence nodes will attempt to execute all of its children and report
-## `SUCCESS` in case all of the children report a `SUCCESS` status code.
-## If at least one child reports a `FAILURE` status code, this node will also
-## return `FAILURE` and restart.
-## In case a child returns `RUNNING` this node will tick again. 
 @tool
 @icon("../../icons/sequence.svg")
 class_name SequenceComposite extends Composite
 
+## Sequence nodes will attempt to execute all of its children and report
+## `SUCCESS` in case all of the children report a `SUCCESS` status code.
+## If at least one child reports a `FAILURE` status code, this node will also
+## return `FAILURE` and restart.
+## In case a child returns `RUNNING` this node will tick again.
 
 var successful_index: int = 0
 

--- a/addons/beehave/nodes/composites/sequence_random.gd
+++ b/addons/beehave/nodes/composites/sequence_random.gd
@@ -1,9 +1,10 @@
-## This node will attempt to execute all of its children just like a
-## [code]SequenceStar[/code] would, with the exception that the children
-## will be executed in a random order.
 @tool
 @icon("../../icons/sequence_random.svg")
 class_name SequenceRandomComposite extends RandomizedComposite
+
+## This node will attempt to execute all of its children just like a
+## [code]SequenceStar[/code] would, with the exception that the children
+## will be executed in a random order.
 
 # Emitted whenever the children are shuffled.
 signal reset(new_order: Array[Node])

--- a/addons/beehave/nodes/composites/sequence_reactive.gd
+++ b/addons/beehave/nodes/composites/sequence_reactive.gd
@@ -1,12 +1,12 @@
+@tool
+@icon("../../icons/sequence_reactive.svg")
+class_name SequenceReactiveComposite extends Composite
+
 ## Reactive Sequence nodes will attempt to execute all of its children and report
 ## `SUCCESS` in case all of the children report a `SUCCESS` status code.
 ## If at least one child reports a `FAILURE` status code, this node will also
 ## return `FAILURE` and restart.
 ## In case a child returns `RUNNING` this node will restart.
-@tool
-@icon("../../icons/sequence_reactive.svg")
-class_name SequenceReactiveComposite extends Composite
-
 
 var successful_index: int = 0
 

--- a/addons/beehave/nodes/composites/sequence_star.gd
+++ b/addons/beehave/nodes/composites/sequence_star.gd
@@ -1,12 +1,12 @@
+@tool
+@icon("../../icons/sequence_reactive.svg")
+class_name SequenceStarComposite extends Composite
+
 ## Sequence Star nodes will attempt to execute all of its children and report
 ## `SUCCESS` in case all of the children report a `SUCCESS` status code.
 ## If at least one child reports a `FAILURE` status code, this node will also
 ## return `FAILURE` and tick again.
 ## In case a child returns `RUNNING` this node will restart.
-@tool
-@icon("../../icons/sequence_reactive.svg")
-class_name SequenceStarComposite extends Composite
-
 
 var successful_index: int = 0
 

--- a/addons/beehave/nodes/decorators/decorator.gd
+++ b/addons/beehave/nodes/decorators/decorator.gd
@@ -1,9 +1,9 @@
-## Decorator nodes are used to transform the result received by its child.
-## Must only have one child.
 @tool
 @icon("../../icons/category_decorator.svg")
 class_name Decorator extends BeehaveNode
 
+## Decorator nodes are used to transform the result received by its child.
+## Must only have one child.
 
 var running_child: BeehaveNode = null
 

--- a/addons/beehave/nodes/decorators/failer.gd
+++ b/addons/beehave/nodes/decorators/failer.gd
@@ -1,8 +1,8 @@
-## A Failer node will always return a `FAILURE` status code.
 @tool
 @icon("../../icons/failer.svg")
 class_name AlwaysFailDecorator extends Decorator
 
+## A Failer node will always return a `FAILURE` status code.
 
 func tick(actor: Node, blackboard: Blackboard) -> int:
 	var c = get_child(0)

--- a/addons/beehave/nodes/decorators/inverter.gd
+++ b/addons/beehave/nodes/decorators/inverter.gd
@@ -1,9 +1,9 @@
-## An inverter will return `FAILURE` in case it's child returns a `SUCCESS` status
-## code or `SUCCESS` in case its child returns a `FAILURE` status code.
 @tool
 @icon("../../icons/inverter.svg")
 class_name InverterDecorator extends Decorator
 
+## An inverter will return `FAILURE` in case it's child returns a `SUCCESS` status
+## code or `SUCCESS` in case its child returns a `FAILURE` status code.
 
 func tick(actor: Node, blackboard: Blackboard) -> int:
 	var c = get_child(0)

--- a/addons/beehave/nodes/decorators/limiter.gd
+++ b/addons/beehave/nodes/decorators/limiter.gd
@@ -1,8 +1,9 @@
-## The limiter will execute its child `x` amount of times. When the number of
-## maximum ticks is reached, it will return a `FAILURE` status code.
 @tool
 @icon("../../icons/limiter.svg")
 class_name LimiterDecorator extends Decorator
+
+## The limiter will execute its child `x` amount of times. When the number of
+## maximum ticks is reached, it will return a `FAILURE` status code.
 
 @onready var cache_key = 'limiter_%s' % self.get_instance_id()
 

--- a/addons/beehave/nodes/decorators/succeeder.gd
+++ b/addons/beehave/nodes/decorators/succeeder.gd
@@ -1,8 +1,8 @@
-## A succeeder node will always return a `SUCCESS` status code.
 @tool
 @icon("../../icons/succeeder.svg")
 class_name AlwaysSucceedDecorator extends Decorator
 
+## A succeeder node will always return a `SUCCESS` status code.
 
 func tick(actor: Node, blackboard: Blackboard) -> int:
 	var c = get_child(0)

--- a/addons/beehave/nodes/decorators/time_limiter.gd
+++ b/addons/beehave/nodes/decorators/time_limiter.gd
@@ -1,9 +1,10 @@
-## The Time Limit Decorator will give its child a set amount of time to finish
-## before interrupting it and return a `FAILURE` status code. The timer is reset
-## every time before the node runs.
 @tool
 @icon("../../icons/limiter.svg")
 class_name TimeLimiterDecorator extends Decorator
+
+## The Time Limit Decorator will give its child a set amount of time to finish
+## before interrupting it and return a `FAILURE` status code. The timer is reset
+## every time before the node runs.
 
 @export var wait_time: = 0.0
 

--- a/addons/beehave/nodes/leaves/action.gd
+++ b/addons/beehave/nodes/leaves/action.gd
@@ -1,11 +1,11 @@
-## Actions are leaf nodes that define a task to be performed by an actor.
-## Their execution can be long running, potentially being called across multiple
-## frame executions. In this case, the node should return `RUNNING` until the
-## action is completed.
 @tool
 @icon("../../icons/action.svg")
 class_name ActionLeaf extends Leaf
 
+## Actions are leaf nodes that define a task to be performed by an actor.
+## Their execution can be long running, potentially being called across multiple
+## frame executions. In this case, the node should return `RUNNING` until the
+## action is completed.
 
 func get_class_name() -> Array[StringName]:
 	var classes := super()

--- a/addons/beehave/nodes/leaves/blackboard_compare.gd
+++ b/addons/beehave/nodes/leaves/blackboard_compare.gd
@@ -1,9 +1,9 @@
-## Compares two values using the specified comparison operator.
-## Returns [code]FAILURE[/code] if any of the expression fails or the
-## comparison operation returns [code]false[/code], otherwise it returns [code]SUCCESS[/code].
 @tool
 class_name BlackboardCompareCondition extends ConditionLeaf
 
+## Compares two values using the specified comparison operator.
+## Returns [code]FAILURE[/code] if any of the expression fails or the
+## comparison operation returns [code]false[/code], otherwise it returns [code]SUCCESS[/code].
 
 enum Operators {
 	EQUAL,

--- a/addons/beehave/nodes/leaves/blackboard_erase.gd
+++ b/addons/beehave/nodes/leaves/blackboard_erase.gd
@@ -1,8 +1,8 @@
-## Erases the specified key from the blackboard.
-## Returns [code]FAILURE[/code] if expression execution fails, otherwise [code]SUCCESS[/code].
 @tool
 class_name BlackboardEraseAction extends ActionLeaf
 
+## Erases the specified key from the blackboard.
+## Returns [code]FAILURE[/code] if expression execution fails, otherwise [code]SUCCESS[/code].
 
 ## Expression representing a blackboard key.
 @export_placeholder(EXPRESSION_PLACEHOLDER) var key: String = ""

--- a/addons/beehave/nodes/leaves/blackboard_has.gd
+++ b/addons/beehave/nodes/leaves/blackboard_has.gd
@@ -1,8 +1,8 @@
-## Returns [code]FAILURE[/code] if expression execution fails or the specified key doesn't exist.
-## Returns [code]SUCCESS[/code] if blackboard has the specified key.
 @tool
 class_name BlackboardHasCondition extends ConditionLeaf
 
+## Returns [code]FAILURE[/code] if expression execution fails or the specified key doesn't exist.
+## Returns [code]SUCCESS[/code] if blackboard has the specified key.
 
 ## Expression representing a blackboard key.
 @export_placeholder(EXPRESSION_PLACEHOLDER) var key: String = ""

--- a/addons/beehave/nodes/leaves/blackboard_set.gd
+++ b/addons/beehave/nodes/leaves/blackboard_set.gd
@@ -1,8 +1,8 @@
-## Sets the specified key to the specified value.
-## Returns [code]FAILURE[/code] if expression execution fails, otherwise [code]SUCCESS[/code].
 @tool
 class_name BlackboardSetAction extends ActionLeaf
 
+## Sets the specified key to the specified value.
+## Returns [code]FAILURE[/code] if expression execution fails, otherwise [code]SUCCESS[/code].
 
 ## Expression representing a blackboard key.
 @export_placeholder(EXPRESSION_PLACEHOLDER) var key: String = ""

--- a/addons/beehave/nodes/leaves/condition.gd
+++ b/addons/beehave/nodes/leaves/condition.gd
@@ -1,9 +1,9 @@
-## Conditions are leaf nodes that either return SUCCESS or FAILURE depending on
-## a single simple condition. They should never return `RUNNING`.
 @tool
 @icon("../../icons/condition.svg")
 class_name ConditionLeaf extends Leaf
 
+## Conditions are leaf nodes that either return SUCCESS or FAILURE depending on
+## a single simple condition. They should never return `RUNNING`.
 
 func get_class_name() -> Array[StringName]:
 	var classes := super()

--- a/addons/beehave/nodes/leaves/leaf.gd
+++ b/addons/beehave/nodes/leaves/leaf.gd
@@ -1,8 +1,8 @@
-## Base class for all leaf nodes of the tree.
 @tool
 @icon("../../icons/category_leaf.svg")
 class_name Leaf extends BeehaveNode
 
+## Base class for all leaf nodes of the tree.
 
 const EXPRESSION_PLACEHOLDER: String = "Insert an expression..."
 


### PR DESCRIPTION
## Description

Class descriptions are now placed under `class_name` declarations. This allows the descriptions to be seen in the editor.

[GDScript documentation comments](https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_documentation_comments.html)

Property descriptions will also appear in the Inspector.

## Addressed issues

- l did not post any issues on this.

## Screenshots

![godot_desc](https://github.com/bitbrain/beehave/assets/15977859/a69b4738-058b-49be-9ad1-c8a37bcaa653)
![godot_desc2](https://github.com/bitbrain/beehave/assets/15977859/b892ec0f-0810-4db2-867e-1054f7c10479)
![godot_desc3](https://github.com/bitbrain/beehave/assets/15977859/12e3007e-2215-4107-9816-d077792250d6)

