### PR TITLE
Add Moving Script Templates to Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ In order to avoid bugs creeping into the codebase, every feature is covered by u
 
 1. [Download Latest Release](https://github.com/bitbrain/beehave/releases/latest)
     - (optional) access latest build for [Godot 3.x](https://github.com/bitbrain/beehave/archive/refs/heads/godot-3.x.zip), [Godot 4.x](https://github.com/bitbrain/beehave/archive/refs/heads/godot-4.x.zip)
-2. Unpack the `beehave` folder into your `/addons` folder within the Godot project
+2. Unpack the `addons/beehave` folder into your `/addons` folder within the Godot project
 3. Enable this addon within the Godot settings: `Project > Project Settings > Plugins`
+4. Move `script_templates` into your project folder.
 
 To better understand what branch to choose from for which Godot version, please refer to this table:
 |Godot Version|Beehave Branch|Beehave Version|


### PR DESCRIPTION
## Description
On `README.md`, I have added one more step to the Installation section. This lets users know that by moving folder `script_templates` into their projects, they can access the script templates.

For consistency, I have also changed folder `beehave` into `addons/beehave` so that users would know that `beehave` is in `addons`.

## Screenshots
![godot_script_template2](https://github.com/bitbrain/beehave/assets/15977859/4fcb1495-3081-4db2-b22a-7cd9c64ee865)
![godot_script_template](https://github.com/bitbrain/beehave/assets/15977859/90e7eac9-18a3-4125-a61c-9270388e5b3b)
