### PR TITLE
Use relative paths when loading autoloads instead of global

### DIFF
--- a/addons/beehave/plugin.gd
+++ b/addons/beehave/plugin.gd
@@ -7,8 +7,8 @@ var frames: RefCounted
 
 func _init():
 	name = "BeehavePlugin"
-	add_autoload_singleton("BeehaveGlobalMetrics", "res://addons/beehave/metrics/beehave_global_metrics.gd")
-	add_autoload_singleton("BeehaveGlobalDebugger", "res://addons/beehave/debug/global_debugger.gd")
+	add_autoload_singleton("BeehaveGlobalMetrics", "./metrics/beehave_global_metrics.gd")
+	add_autoload_singleton("BeehaveGlobalDebugger", "./debug/global_debugger.gd")
 	print("Beehave initialized!")
 
 


### PR DESCRIPTION
## Description

Use relative paths when loading autoloads instead of global.
This allows moving the beehave folder anywhere without it breaking.

Previous:
```gdscript
	add_autoload_singleton("BeehaveGlobalMetrics", "res://addons/beehave/metrics/beehave_global_metrics.gd")
	add_autoload_singleton("BeehaveGlobalDebugger", "res://addons/beehave/debug/global_debugger.gd")
```
This PR:
```gdscript
	add_autoload_singleton("BeehaveGlobalMetrics", "./metrics/beehave_global_metrics.gd")
	add_autoload_singleton("BeehaveGlobalDebugger", "./debug/global_debugger.gd")
```

## Addressed issues

Probably Closes #237

## Screenshots

N/A Not required.
