### PR TITLE
:bug: expose blackboard properties correctly

### DIFF
--- a/addons/beehave/blackboard.gd
+++ b/addons/beehave/blackboard.gd
@@ -1,34 +1,47 @@
 @icon("icons/blackboard.svg")
 class_name Blackboard extends Node
 
+
+const DEFAULT = "default"
+
+
 ## The blackboard is an object that can be used to store and access data between
 ## multiple nodes of the behavior tree.
+@export var blackboard: Dictionary = {}:
+	set(b):
+		blackboard = b
+		_data[DEFAULT] = blackboard
 
-@export var blackboard: Dictionary = {}
+
+var _data:Dictionary = {}
+
+
+func _ready():
+	_data[DEFAULT] = blackboard
+
 
 func keys() -> Array[String]:
 	var keys: Array[String]
-	keys.assign(blackboard.keys().duplicate())
+	keys.assign(_data.keys().duplicate())
 	return keys
 
+func set_value(key: Variant, value: Variant, blackboard_name: String = DEFAULT) -> void:
+	if not _data.has(blackboard_name):
+		_data[blackboard_name] = {}
 
-func set_value(key: Variant, value: Variant, blackboard_name: String = 'default') -> void:
-	if not blackboard.has(blackboard_name):
-		blackboard[blackboard_name] = {}
-
-	blackboard[blackboard_name][key] = value
+	_data[blackboard_name][key] = value
 
 
-func get_value(key: Variant, default_value: Variant = null, blackboard_name: String = 'default') -> Variant:
+func get_value(key: Variant, default_value: Variant = null, blackboard_name: String = DEFAULT) -> Variant:
 	if has_value(key, blackboard_name):
-		return blackboard[blackboard_name].get(key, default_value)
+		return _data[blackboard_name].get(key, default_value)
 	return default_value
 
 
-func has_value(key: Variant, blackboard_name: String = 'default') -> bool:
-	return blackboard.has(blackboard_name) and blackboard[blackboard_name].has(key) and blackboard[blackboard_name][key] != null
+func has_value(key: Variant, blackboard_name: String = DEFAULT) -> bool:
+	return _data.has(blackboard_name) and _data[blackboard_name].has(key) and _data[blackboard_name][key] != null
 
 
-func erase_value(key: Variant, blackboard_name: String = 'default') -> void:
-	if blackboard.has(blackboard_name):
-		blackboard[blackboard_name][key] = null
+func erase_value(key: Variant, blackboard_name: String = DEFAULT) -> void:
+	if _data.has(blackboard_name):
+		_data[blackboard_name][key] = null

--- a/addons/gdUnit4/GdUnitRunner.cfg
+++ b/addons/gdUnit4/GdUnitRunner.cfg
@@ -1,1 +1,1 @@
-{"included":{"res://test/":[]},"server_port":31002,"skipped":{},"version":"1.0"}
+{"included":{"res://test/blackboard/blackboard_test.gd":["test_blackboard_property_shared_between_trees"]},"server_port":31002,"skipped":{},"version":"1.0"}

--- a/test/blackboard/blackboard_register_action.gd
+++ b/test/blackboard/blackboard_register_action.gd
@@ -1,0 +1,10 @@
+extends ActionLeaf
+
+
+var blackboard
+
+
+func tick(actor, blackboard: Blackboard):
+	self.blackboard = blackboard
+	return SUCCESS
+

--- a/test/blackboard/blackboard_test.gd
+++ b/test/blackboard/blackboard_test.gd
@@ -51,3 +51,16 @@ func test_blackboard_shared_between_trees() -> void:
 	assert_that(scene.blackboard.get_value("custom_value")).is_equal(4)
 	assert_that(scene.blackboard.get_value("custom_value")).is_equal(4)
 	assert_that(scene.blackboard.keys().size()).is_equal(3)
+
+
+func test_blackboard_property_shared_between_trees() -> void:
+	var scene = auto_free(load("res://test/blackboard/shared_blackboard_scene.tscn").instantiate())
+	var runner = scene_runner(scene)
+	
+	await runner.simulate_frames(10)
+	
+	var blackboard1:Blackboard = scene.beehave_tree_1.get_child(0).blackboard
+	var blackboard2:Blackboard = scene.beehave_tree_2.get_child(0).blackboard
+	
+	assert_that(blackboard1.get_value("hello")).is_equal("world")
+	assert_that(blackboard2.get_value("hello")).is_equal("world")

--- a/test/blackboard/shared_blackboard_scene.gd
+++ b/test/blackboard/shared_blackboard_scene.gd
@@ -1,0 +1,6 @@
+extends Node2D
+
+
+@onready var blackboard = %Blackboard
+@onready var beehave_tree_1 = %BeehaveTree1
+@onready var beehave_tree_2 = %BeehaveTree2

--- a/test/blackboard/shared_blackboard_scene.tscn
+++ b/test/blackboard/shared_blackboard_scene.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=5 format=3 uid="uid://ro5hjc002h0r"]
+
+[ext_resource type="Script" path="res://test/blackboard/shared_blackboard_scene.gd" id="1_8ck4i"]
+[ext_resource type="Script" path="res://addons/beehave/blackboard.gd" id="2_fg0hi"]
+[ext_resource type="Script" path="res://addons/beehave/nodes/beehave_tree.gd" id="3_aaudw"]
+[ext_resource type="Script" path="res://test/blackboard/blackboard_register_action.gd" id="4_ijv65"]
+
+[node name="SharedBlackboardScene" type="Node2D"]
+script = ExtResource("1_8ck4i")
+
+[node name="Blackboard" type="Node" parent="."]
+unique_name_in_owner = true
+script = ExtResource("2_fg0hi")
+blackboard = {
+"hello": "world"
+}
+
+[node name="BeehaveTree1" type="Node" parent="." node_paths=PackedStringArray("blackboard", "actor")]
+unique_name_in_owner = true
+script = ExtResource("3_aaudw")
+blackboard = NodePath("../Blackboard")
+actor = NodePath("..")
+
+[node name="ActionLeaf" type="Node" parent="BeehaveTree1"]
+script = ExtResource("4_ijv65")
+
+[node name="BeehaveTree2" type="Node" parent="." node_paths=PackedStringArray("blackboard", "actor")]
+unique_name_in_owner = true
+script = ExtResource("3_aaudw")
+blackboard = NodePath("../Blackboard")
+actor = NodePath("..")
+
+[node name="ActionLeaf" type="Node" parent="BeehaveTree2"]
+script = ExtResource("4_ijv65")


### PR DESCRIPTION
Closes #293

# Description

The issue was that we accidentally exposed the inner state of a blackboard. However, blackboards internally have a dictionary of dictionaries. Instead, we ensure to only expose the default blackboard via properties.
