### PR TITLE
Dont override actor in _ready if already defined

### DIFF
--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -110,10 +110,11 @@ func _ready() -> void:
 	if not process_thread:
 		process_thread = ProcessThread.PHYSICS
 
-	if actor_node_path:
-		actor = get_node(actor_node_path)
-	else:
-		actor = get_parent()
+	if not actor:
+		if actor_node_path:
+			actor = get_node(actor_node_path)
+		else:
+			actor = get_parent()
 
 	if not blackboard:
 		# invoke setter to auto-initialise the blackboard.

--- a/test/beehave_tree_test.gd
+++ b/test/beehave_tree_test.gd
@@ -97,3 +97,13 @@ func test_blackboard_not_initialized() -> void:
 	tree.add_child(always_succeed)
 	var result = tree.tick()
 	assert_that(result).is_equal(BeehaveNode.SUCCESS)
+
+
+func test_actor_override() -> void:
+	var scene = create_scene()
+	scene_runner(scene)
+	var tree = create_tree()
+	var actor = auto_free(Node2D.new())
+	tree.actor = actor
+	scene.add_child(tree)
+	assert_that(tree.actor).is_equal(actor)


### PR DESCRIPTION
## Description

If you set the actor in `BeehaveTree` before `_ready` is executed, it would override the actor that you set.

Now it only sets the actor if it isn't already set.

## Addressed issues

- None

## Screenshots

N/A
