### PR TITLE
Fix reloading scene debug issue

### DIFF
--- a/addons/beehave/debug/global_debugger.gd
+++ b/addons/beehave/debug/global_debugger.gd
@@ -13,7 +13,7 @@ func _on_debug_message(message: String, data: Array) -> bool:
 		_set_active_tree(data[0])
 		return true
 	if message == "visibility_changed":
-		if _active_tree:
+		if _active_tree && is_instance_valid(_active_tree):
 			_active_tree._can_send_message = data[0]
 		return true
 	return false
@@ -24,7 +24,7 @@ func _set_active_tree(tree_id: int) -> void:
 	if not tree:
 		return
 
-	if _active_tree:
+	if _active_tree && is_instance_valid(_active_tree):
 		_active_tree._can_send_message = false
 	_active_tree = tree
 	_active_tree._can_send_message = true

--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -147,17 +147,17 @@ func _on_scene_tree_node_added_removed(node: Node, is_added: bool) -> void:
 	if Engine.is_editor_hint():
 		return
 
-  if node is BeehaveNode and is_ancestor_of(node):
-    var sgnal := node.ready if is_added else node.tree_exited
-    if is_added:
-      sgnal.connect(
-        func() -> void: BeehaveDebuggerMessages.register_tree(_get_debugger_data(self)),
-        CONNECT_ONE_SHOT
-      )
-    else:
-      sgnal.connect(
-        func() -> void: BeehaveDebuggerMessages.unregister_tree(get_instance_id())
-      )
+	if node is BeehaveNode and is_ancestor_of(node):
+		var sgnal := node.ready if is_added else node.tree_exited
+		if is_added:
+			sgnal.connect(
+				func() -> void: BeehaveDebuggerMessages.register_tree(_get_debugger_data(self)),
+				CONNECT_ONE_SHOT
+			)
+		else:
+			sgnal.connect(
+				func() -> void: BeehaveDebuggerMessages.unregister_tree(get_instance_id())
+			)
 
 
 func _physics_process(_delta: float) -> void:

--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -147,12 +147,17 @@ func _on_scene_tree_node_added_removed(node: Node, is_added: bool) -> void:
 	if Engine.is_editor_hint():
 		return
 
-	if node is BeehaveNode and is_ancestor_of(node):
-		var sgnal := node.ready if is_added else node.tree_exited
-		sgnal.connect(
-			func() -> void: BeehaveDebuggerMessages.register_tree(_get_debugger_data(self)),
-			CONNECT_ONE_SHOT
-		)
+  if node is BeehaveNode and is_ancestor_of(node):
+    var sgnal := node.ready if is_added else node.tree_exited
+    if is_added:
+      sgnal.connect(
+        func() -> void: BeehaveDebuggerMessages.register_tree(_get_debugger_data(self)),
+        CONNECT_ONE_SHOT
+      )
+    else:
+      sgnal.connect(
+        func() -> void: BeehaveDebuggerMessages.unregister_tree(get_instance_id())
+      )
 
 
 func _physics_process(_delta: float) -> void:


### PR DESCRIPTION
## Description

When you reload the scene, it seems that behaviour trees are not unregistered properly for debugging purposes. That means they will keep being in the Beehave debug tab and the Debugger output will be flooded with a lot of error messages.

## Screenshots

![image](https://github.com/bitbrain/beehave/assets/8688472/be223857-2c2d-4f4a-bfef-9f54970d8775)
