### PR TITLE
Issue #328 - Make the RandomizedComposite node know when to remove weights when children exit

### DIFF
--- a/test/randomized_composites/runtime_changes/RuntimeChangesTestScene.gd
+++ b/test/randomized_composites/runtime_changes/RuntimeChangesTestScene.gd
@@ -1,3 +1,9 @@
 extends Node2D
 
 @onready var sequence_random: SequenceRandomComposite = %SequenceRandom
+
+func set_weights(idle: int, run: int, attack_meele: int, attack_ranged: int):
+	sequence_random.set("Weights/Idle", idle)
+	sequence_random.set("Weights/Run", run)
+	sequence_random.set("Weights/Attack Meele", attack_meele)
+	sequence_random.set("Weights/Attack Ranged", attack_ranged)

--- a/test/randomized_composites/runtime_changes/runtime_changes_test.gd
+++ b/test/randomized_composites/runtime_changes/runtime_changes_test.gd
@@ -103,3 +103,33 @@ func test_rename_child() -> void:
 				.contains_key_value(node, weights_before[node])
 	
 	runner.simulate_frames(10) # Everything should work fine afterwards.
+
+func test_scene_reload() -> void:
+	var scene = create_scene()
+	var runner := scene_runner(scene)
+	
+	runner.set_time_factor(100.0)
+	
+	# set the Idle weight to non-default
+	scene.set_weights(2, 3, 4, 5)
+	
+	var sequence_random: SequenceRandomComposite = scene.sequence_random
+	var weights_before: Dictionary = sequence_random._weights.duplicate()
+	
+	runner.simulate_frames(10)
+	
+	var beehave_tree = runner.find_child("BeehaveTree")
+	beehave_tree.remove_child(sequence_random)
+	
+	runner.simulate_frames(10)
+	
+	beehave_tree.add_child(sequence_random)
+	
+	# Weights should be exactly the same.
+	var children = weights_before.keys()
+	for node in children:
+		assert_dict(sequence_random._weights)\
+				.contains_key_value(node, weights_before[node])
+	
+	runner.simulate_frames(10) # Everything should work fine afterwards.
+	

--- a/test/randomized_composites/runtime_changes/runtime_changes_test.gd
+++ b/test/randomized_composites/runtime_changes/runtime_changes_test.gd
@@ -116,12 +116,12 @@ func test_scene_reload() -> void:
 	var sequence_random: SequenceRandomComposite = scene.sequence_random
 	var weights_before: Dictionary = sequence_random._weights.duplicate()
 	
-	runner.simulate_frames(10)
+	await runner.simulate_frames(10)
 	
 	var beehave_tree = runner.find_child("BeehaveTree")
 	beehave_tree.remove_child(sequence_random)
 	
-	runner.simulate_frames(10)
+	await runner.simulate_frames(10)
 	
 	beehave_tree.add_child(sequence_random)
 	
@@ -131,5 +131,5 @@ func test_scene_reload() -> void:
 		assert_dict(sequence_random._weights)\
 				.contains_key_value(node, weights_before[node])
 	
-	runner.simulate_frames(10) # Everything should work fine afterwards.
+	await runner.simulate_frames(10) # Everything should work fine afterwards.
 	


### PR DESCRIPTION
## Description

- Added a test for verifying the issue of weight being reset when a child node of a RandomizedComposite exits and reenters the tree 
- Updated the RandomizedComposite node to check whether the whole node is exiting or not to decide whether to remove weight information when children nodes are exiting

## Addressed issues

- Issue #328 

## Screenshots

Navigating away and back resets all weights to 1
![image](https://github.com/bitbrain/beehave/assets/3381769/90a4bdcb-b325-49f1-b9eb-fb1094a0b1d5)

Now navigating away and back maintains weights
![image](https://github.com/bitbrain/beehave/assets/3381769/e9155c35-684d-4352-9ecc-48a69915e4d3)
