### PR TITLE
Register trees in debugger tab again when added back to scene

### DIFF
--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -104,8 +104,11 @@ var _can_send_message: bool = false
 
 
 func _ready() -> void:
-	get_tree().node_added.connect(_on_scene_tree_node_added_removed.bind(true))
-	get_tree().node_removed.connect(_on_scene_tree_node_added_removed.bind(false))
+	var connect_scene_tree_signal = func(signal_name: String, is_added: bool):
+		if not get_tree().is_connected(signal_name, _on_scene_tree_node_added_removed.bind(is_added)):
+			get_tree().connect(signal_name, _on_scene_tree_node_added_removed.bind(is_added))
+	connect_scene_tree_signal.call("node_added", true)
+	connect_scene_tree_signal.call("node_removed", false)
 
 	if not process_thread:
 		process_thread = ProcessThread.PHYSICS
@@ -156,7 +159,9 @@ func _on_scene_tree_node_added_removed(node: Node, is_added: bool) -> void:
 			)
 		else:
 			sgnal.connect(
-				func() -> void: BeehaveDebuggerMessages.unregister_tree(get_instance_id())
+				func() -> void:
+					BeehaveDebuggerMessages.unregister_tree(get_instance_id())
+					request_ready()
 			)
 
 

--- a/examples/beehave_test_scene.gd
+++ b/examples/beehave_test_scene.gd
@@ -1,10 +1,10 @@
 extends Node2D
 
 @onready var sprite := $ColorChangingSprite
+@onready var another_sprite := $AnotherSprite
 @onready var tree := %BeehaveTree
 @onready var condition_label := %ConditionLabel
 @onready var action_label := %ActionLabel
-
 
 func _process(delta:float) -> void:
 	if Input.is_action_pressed("ui_left"):
@@ -28,3 +28,17 @@ func _process(delta:float) -> void:
 		action_label.text = str(tree.get_running_action(), " -> RUNNING")
 	else:
 		action_label.text = "no running action"
+
+	# The following are used to verify if the beehave trees show up or get
+	# removed from the debug panel when various scene operations occur.
+	if Input.is_action_just_pressed("ui_text_delete") and another_sprite.is_inside_tree():
+		another_sprite.get_parent().remove_child(another_sprite)
+
+	if Input.is_action_just_pressed("ui_accept") and not another_sprite.is_inside_tree():
+		add_child(another_sprite)
+
+	if Input.is_action_just_pressed("ui_undo"):
+		get_tree().reload_current_scene()
+
+	if Input.is_action_just_pressed("ui_cut"):
+		another_sprite.reparent(get_node("Background"))


### PR DESCRIPTION
This pull request ensures beehave trees are registered again if they are added back into the scene after being removed.

Fixes
- closes #338

Related past pull requests:
- #301
- #310


https://github.com/bitbrain/beehave/assets/56014779/edb3ac93-e6f1-415a-94f9-02ff2b105f55

