### PR TITLE
Fix misspelling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Using behavior trees, Beehave makes it simple to create highly adaptive AI that 
 
 ### 🤖 Node based - build behavior trees within your scene tree
 
-Compose behavior trees in your scene and attach them to any node of your chosing.
+Compose behavior trees in your scene and attach them to any node of your choice.
 
 <img src="docs/assets/beehave-demo-tree.png" width="450px"/>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Using behavior trees, Beehave makes it simple to create highly adaptive AI that 
 
 ### 🤖 Node based - build behavior trees within your scene tree
 
-Compose behavior trees in your scene and attach them to any node of your chosing.
+Compose behavior trees in your scene and attach them to any node of your choice.
 
 <img src="assets/beehave-demo-tree.png" width="450px"/>
 


### PR DESCRIPTION
## Description

Fixed misspelling of "choosing" and replaced with "choice" to better fit grammatically.

## Screenshots

![Screenshot 2024-09-17 001302](https://github.com/user-attachments/assets/ecc8c800-d237-4127-a266-d1d32aedfb40)
