### PR TITLE
Add blackboard debugging

### DIFF
--- a/addons/beehave/blackboard.gd
+++ b/addons/beehave/blackboard.gd
@@ -49,3 +49,6 @@ func has_value(key: Variant, blackboard_name: String = DEFAULT) -> bool:
 func erase_value(key: Variant, blackboard_name: String = DEFAULT) -> void:
 	if _data.has(blackboard_name):
 		_data[blackboard_name][key] = null
+
+func get_debug_data() -> Dictionary:
+	return _data

--- a/addons/beehave/debug/debugger.gd
+++ b/addons/beehave/debug/debugger.gd
@@ -25,13 +25,13 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 		debugger_tab.unregister_tree(data[0])
 		return true
 	if message == "beehave:process_tick":
-		debugger_tab.graph.process_tick(data[0], data[1])
+		debugger_tab.graph.process_tick(data[0], data[1], data[2])
 		return true
 	if message == "beehave:process_begin":
-		debugger_tab.graph.process_begin(data[0])
+		debugger_tab.graph.process_begin(data[0], data[1])
 		return true
 	if message == "beehave:process_end":
-		debugger_tab.graph.process_end(data[0])
+		debugger_tab.graph.process_end(data[0], data[1])
 		return true
 	return false
 

--- a/addons/beehave/debug/debugger_messages.gd
+++ b/addons/beehave/debug/debugger_messages.gd
@@ -15,16 +15,16 @@ static func unregister_tree(instance_id: int) -> void:
 		EngineDebugger.send_message("beehave:unregister_tree", [instance_id])
 
 
-static func process_tick(instance_id: int, status: int) -> void:
+static func process_tick(instance_id: int, status: int, blackboard: Dictionary = {}) -> void:
 	if can_send_message():
-		EngineDebugger.send_message("beehave:process_tick", [instance_id, status])
+		EngineDebugger.send_message("beehave:process_tick", [instance_id, status, blackboard])
 
 
-static func process_begin(instance_id: int) -> void:
+static func process_begin(instance_id: int, blackboard: Dictionary = {}) -> void:
 	if can_send_message():
-		EngineDebugger.send_message("beehave:process_begin", [instance_id])
+		EngineDebugger.send_message("beehave:process_begin", [instance_id, blackboard])
 
 
-static func process_end(instance_id: int) -> void:
+static func process_end(instance_id: int, blackboard: Dictionary = {}) -> void:
 	if can_send_message():
-		EngineDebugger.send_message("beehave:process_end", [instance_id])
+		EngineDebugger.send_message("beehave:process_end", [instance_id, blackboard])

--- a/addons/beehave/debug/debugger_tab.gd
+++ b/addons/beehave/debug/debugger_tab.gd
@@ -7,12 +7,15 @@ signal make_floating
 
 const OldBeehaveGraphEdit := preload("old_graph_edit.gd")
 const NewBeehaveGraphEdit := preload("new_graph_edit.gd")
+const NewNodeBlackBoard := preload("new_node_blackboard.gd")
 
 const TREE_ICON := preload("../icons/tree.svg")
 
 var graph
 var container: HSplitContainer
+var graph_container: HSplitContainer
 var item_list: ItemList
+var blackboard_vbox: VBoxContainer
 var message: Label
 
 var active_trees: Dictionary
@@ -28,12 +31,25 @@ func _ready() -> void:
 	item_list.custom_minimum_size = Vector2(200, 0)
 	item_list.item_selected.connect(_on_item_selected)
 	container.add_child(item_list)
+
+	graph_container = HSplitContainer.new()
+	graph_container.split_offset = 1920
+	graph_container.set_anchors_preset(Control.PRESET_FULL_RECT)
+	container.add_child(graph_container)
+
 	if Engine.get_version_info().minor >= 2:
 		graph = NewBeehaveGraphEdit.new(BeehaveUtils.get_frames())
 	else:
 		graph = OldBeehaveGraphEdit.new(BeehaveUtils.get_frames())
 
-	container.add_child(graph)
+	graph.node_selected.connect(_on_graph_node_selected)
+	graph.node_deselected.connect(_on_graph_node_deselected)
+	graph_container.add_child(graph)
+
+	blackboard_vbox = VBoxContainer.new()
+	blackboard_vbox.custom_minimum_size = Vector2(200, 0)
+	blackboard_vbox.set_anchors_preset(Control.PRESET_FULL_RECT)
+	graph_container.add_child(blackboard_vbox)
 
 	message = Label.new()
 	message.text = "Run Project for debugging"
@@ -115,9 +131,25 @@ func _on_item_selected(idx: int) -> void:
 	var id: StringName = item_list.get_item_metadata(idx)
 	graph.beehave_tree = active_trees.get(id, {})
 
+	# Clear our any loaded blackboards
+	for child in blackboard_vbox.get_children():
+		child.free()
+
 	active_tree_id = id.to_int()
 	if session != null:
 		session.send_message("beehave:activate_tree", [active_tree_id])
+
+func _on_graph_node_selected(node: GraphNode) -> void:
+	var node_blackboard: VBoxContainer = NewNodeBlackBoard.new(BeehaveUtils.get_frames(), node)
+	blackboard_vbox.add_child(node_blackboard)
+
+func _on_graph_node_deselected(node: GraphNode) -> void:
+	var matches: Array = blackboard_vbox\
+		.get_children()\
+		.filter(func (child): return child.name == node.name)
+
+	for child in matches:
+		child.free()
 
 
 func _on_visibility_changed() -> void:

--- a/addons/beehave/debug/new_graph_edit.gd
+++ b/addons/beehave/debug/new_graph_edit.gd
@@ -150,7 +150,7 @@ func get_status(status: int) -> String:
 	return "RUNNING"
 
 
-func process_begin(instance_id: int) -> void:
+func process_begin(instance_id: int, blackboard = null) -> void:
 	if not _is_same_tree(instance_id):
 		return
 
@@ -158,18 +158,19 @@ func process_begin(instance_id: int) -> void:
 		child.set_meta("status", -1)
 
 
-func process_tick(instance_id: int, status: int) -> void:
+func process_tick(instance_id: int, status: int, blackboard = null) -> void:
 	var node := get_node_or_null(str(instance_id))
 	if node:
 		node.text = "Status: %s" % get_status(status)
 		node.set_status(status)
 		node.set_meta("status", status)
+		node.blackboard = blackboard
 		if status == BeehaveNode.SUCCESS or status == BeehaveNode.RUNNING:
 			if not active_nodes.has(node.name):
 				active_nodes.push_back(node.name)
 
 
-func process_end(instance_id: int) -> void:
+func process_end(instance_id: int, blackboard = null) -> void:
 	if not _is_same_tree(instance_id):
 		return
 

--- a/addons/beehave/debug/new_graph_node.gd
+++ b/addons/beehave/debug/new_graph_node.gd
@@ -1,6 +1,7 @@
 @tool
 extends GraphNode
 
+signal blackboard_updated
 
 const BeehaveUtils := preload("res://addons/beehave/utils/utils.gd")
 
@@ -27,6 +28,11 @@ const PORT_RIGHT_ICON := preload("icons/port_right.svg")
 		icon = value
 		if icon_rect:
 			icon_rect.texture = value
+
+@export var blackboard: Dictionary:
+	set(value):
+		blackboard = value
+		blackboard_updated.emit()
 
 var layout_size: float:
 	get:

--- a/addons/beehave/debug/new_node_blackboard.gd
+++ b/addons/beehave/debug/new_node_blackboard.gd
@@ -1,0 +1,76 @@
+extends VBoxContainer
+
+var frames: RefCounted
+var graph_node: GraphNode
+
+var item_tree: Tree
+
+func _init(frames: RefCounted, node: GraphNode) -> void:
+	self.frames = frames
+	graph_node = node
+
+	graph_node.blackboard_updated.connect(_update_list)
+
+func _ready() -> void:
+	name = graph_node.name
+
+	set_anchors_preset(Control.PRESET_FULL_RECT)
+
+	var title_panel: Panel = Panel.new()
+	title_panel.set_anchors_preset(Control.PRESET_FULL_RECT)
+	title_panel.custom_minimum_size = Vector2(200, 50)
+	add_child(title_panel)
+	var title_hbox: HBoxContainer = HBoxContainer.new()
+	title_hbox.alignment = BoxContainer.ALIGNMENT_CENTER
+	title_hbox.set_anchors_preset(Control.PRESET_FULL_RECT)
+	title_panel.add_child(title_hbox)
+
+	var icon_rect: TextureRect = TextureRect.new()
+	icon_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	icon_rect.texture = graph_node.icon
+	icon_rect.set_size(Vector2(20, 20))
+	title_hbox.add_child(icon_rect)
+
+	var title: Label = Label.new()
+	title.text = graph_node.title_text
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	title.set_anchors_preset(Control.PRESET_FULL_RECT)
+	title_hbox.add_child(title)
+
+	item_tree = Tree.new()
+	item_tree.custom_minimum_size = Vector2(200, 400)
+	item_tree.hide_root = true
+	item_tree.allow_search = false
+	item_tree.columns = 2
+	add_child(item_tree)
+
+	_update_list()
+
+func _update_list() -> void:
+	item_tree.clear()
+
+	var root: TreeItem = item_tree.create_item()
+
+	if graph_node.blackboard.size() == 0:
+		var no_bb_message: TreeItem = item_tree.create_item(root)
+		no_bb_message.set_text(0, "No blackboard data")
+		return
+
+	for bb_name in graph_node.blackboard:
+		var bb_name_branch: TreeItem = item_tree.create_item(root)
+		bb_name_branch.set_text(0, bb_name)
+
+		#print(graph_node.blackboard.get(bb_name))
+		for key in graph_node.blackboard.get(bb_name):
+			var bb_kv_leaf: TreeItem = item_tree.create_item(bb_name_branch)
+			bb_kv_leaf.set_text(0, str(key))
+			bb_kv_leaf.set_text(1, str(graph_node.blackboard.get(bb_name).get(key)))
+
+func _get_icon(type: StringName) -> Texture2D:
+	var classes := ProjectSettings.get_global_class_list()
+	for c in classes:
+		if c["class"] == type:
+			var icon_path := c.get("icon", String())
+			if not icon_path.is_empty():
+				return load(icon_path)
+	return null

--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -189,13 +189,13 @@ func _process_internally() -> void:
 	blackboard.set_value("can_send_message", _can_send_message)
 
 	if _can_send_message:
-		BeehaveDebuggerMessages.process_begin(get_instance_id())
+		BeehaveDebuggerMessages.process_begin(get_instance_id(), blackboard.get_debug_data())
 
 	if self.get_child_count() == 1:
 		tick()
 
 	if _can_send_message:
-		BeehaveDebuggerMessages.process_end(get_instance_id())
+		BeehaveDebuggerMessages.process_end(get_instance_id(), blackboard.get_debug_data())
 
 	# Check the cost for this frame and save it for metric report
 	_process_time_metric_value = Time.get_ticks_usec() - start_time
@@ -210,8 +210,8 @@ func tick() -> int:
 
 	status = child.tick(actor, blackboard)
 	if _can_send_message:
-		BeehaveDebuggerMessages.process_tick(child.get_instance_id(), status)
-		BeehaveDebuggerMessages.process_tick(get_instance_id(), status)
+		BeehaveDebuggerMessages.process_tick(child.get_instance_id(), status, blackboard.get_debug_data())
+		BeehaveDebuggerMessages.process_tick(get_instance_id(), status, blackboard.get_debug_data())
 
 	# Clear running action if nothing is running
 	if status != RUNNING:

--- a/addons/beehave/nodes/composites/selector.gd
+++ b/addons/beehave/nodes/composites/selector.gd
@@ -20,7 +20,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 		var response: int = c.tick(actor, blackboard)
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 		if c is ConditionLeaf:
 			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/composites/selector_random.gd
+++ b/addons/beehave/nodes/composites/selector_random.gd
@@ -30,7 +30,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 		var response: int = c.tick(actor, blackboard)
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 		if c is ConditionLeaf:
 			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/composites/selector_reactive.gd
+++ b/addons/beehave/nodes/composites/selector_reactive.gd
@@ -15,7 +15,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 		var response: int = c.tick(actor, blackboard)
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 		if c is ConditionLeaf:
 			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/composites/sequence.gd
+++ b/addons/beehave/nodes/composites/sequence.gd
@@ -21,7 +21,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 		var response: int = c.tick(actor, blackboard)
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 		if c is ConditionLeaf:
 			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/composites/sequence_random.gd
+++ b/addons/beehave/nodes/composites/sequence_random.gd
@@ -38,7 +38,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 		var response: int = c.tick(actor, blackboard)
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 		if c is ConditionLeaf:
 			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/composites/sequence_reactive.gd
+++ b/addons/beehave/nodes/composites/sequence_reactive.gd
@@ -21,7 +21,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 		var response: int = c.tick(actor, blackboard)
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 		if c is ConditionLeaf:
 			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/composites/sequence_star.gd
+++ b/addons/beehave/nodes/composites/sequence_star.gd
@@ -21,7 +21,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 		var response: int = c.tick(actor, blackboard)
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 		if c is ConditionLeaf:
 			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/composites/simple_parallel.gd
+++ b/addons/beehave/nodes/composites/simple_parallel.gd
@@ -46,7 +46,7 @@ func tick(actor, blackboard: Blackboard):
 
 			var response: int = c.tick(actor, blackboard)
 			if can_send_message(blackboard):
-				BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+				BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 			delayed_result = response
 			match response:

--- a/addons/beehave/nodes/decorators/cooldown.gd
+++ b/addons/beehave/nodes/decorators/cooldown.gd
@@ -28,12 +28,12 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		blackboard.set_value(cache_key, remaining_time, str(actor.get_instance_id()))
 
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(self.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(self.get_instance_id(), response, blackboard.get_debug_data())
 	else:
 		response = c.tick(actor, blackboard)
 
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 		if c is ConditionLeaf:
 			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/decorators/delayer.gd
+++ b/addons/beehave/nodes/decorators/delayer.gd
@@ -28,12 +28,12 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		blackboard.set_value(cache_key, total_time, str(actor.get_instance_id()))
 
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(self.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(self.get_instance_id(), response, blackboard.get_debug_data())
 	else:
 		response = c.tick(actor, blackboard)
 
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 		if c is ConditionLeaf:
 			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/decorators/failer.gd
+++ b/addons/beehave/nodes/decorators/failer.gd
@@ -13,7 +13,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 	var response: int = c.tick(actor, blackboard)
 	if can_send_message(blackboard):
-		BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+		BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 	if c is ConditionLeaf:
 		blackboard.set_value("last_condition", c, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/decorators/inverter.gd
+++ b/addons/beehave/nodes/decorators/inverter.gd
@@ -14,7 +14,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 	var response: int = c.tick(actor, blackboard)
 	if can_send_message(blackboard):
-		BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+		BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 	if c is ConditionLeaf:
 		blackboard.set_value("last_condition", c, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/decorators/limiter.gd
+++ b/addons/beehave/nodes/decorators/limiter.gd
@@ -22,7 +22,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		blackboard.set_value(cache_key, current_count + 1, str(actor.get_instance_id()))
 		var response: int = child.tick(actor, blackboard)
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(child.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(child.get_instance_id(), response, blackboard.get_debug_data())
 
 		if child is ConditionLeaf:
 			blackboard.set_value("last_condition", child, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/decorators/repeater.gd
+++ b/addons/beehave/nodes/decorators/repeater.gd
@@ -23,7 +23,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		var response: int = child.tick(actor, blackboard)
 
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(child.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(child.get_instance_id(), response, blackboard.get_debug_data())
 
 		if child is ConditionLeaf:
 			blackboard.set_value("last_condition", child, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/decorators/succeeder.gd
+++ b/addons/beehave/nodes/decorators/succeeder.gd
@@ -13,7 +13,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 	var response: int = c.tick(actor, blackboard)
 	if can_send_message(blackboard):
-		BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+		BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 	if c is ConditionLeaf:
 		blackboard.set_value("last_condition", c, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/decorators/time_limiter.gd
+++ b/addons/beehave/nodes/decorators/time_limiter.gd
@@ -23,7 +23,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 		blackboard.set_value(cache_key, time_left, str(actor.get_instance_id()))
 		var response: int = child.tick(actor, blackboard)
 		if can_send_message(blackboard):
-			BeehaveDebuggerMessages.process_tick(child.get_instance_id(), response)
+			BeehaveDebuggerMessages.process_tick(child.get_instance_id(), response, blackboard.get_debug_data())
 
 		if child is ConditionLeaf:
 			blackboard.set_value("last_condition", child, str(actor.get_instance_id()))

--- a/addons/beehave/nodes/decorators/until_fail.gd
+++ b/addons/beehave/nodes/decorators/until_fail.gd
@@ -16,7 +16,7 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 	var response: int = c.tick(actor, blackboard)
 	if can_send_message(blackboard):
-		BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response)
+		BeehaveDebuggerMessages.process_tick(c.get_instance_id(), response, blackboard.get_debug_data())
 
 	if c is ConditionLeaf:
 		blackboard.set_value("last_condition", c, str(actor.get_instance_id()))


### PR DESCRIPTION
## Description

Adds debugging of blackboard data. Select one or more nodes in the debug tab and the blackboard data associated with that node appears on the right. The data updates in real time. RIght column is resizeable.

This PR is backwards compatible as the new argument added to `BeehaveDebuggerMessages.process_` isn't required and defaults to an empty dictionary.

## Addressed issues

- It can be difficult to know what your blackboard is doing a state machine is running. This PR greatly helps with that.

## Screenshots

https://github.com/user-attachments/assets/8cc0db58-b5ea-4553-b40a-07791d6b785d

