### PR TITLE
Ignore gdunit update folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 **/*.import
 export.cfg
 export_presets.cfg
+addons/gdUnit4/tmp-update/
+
 
 # Mono-specific ignores
 .mono/


### PR DESCRIPTION
## Description

Adds gdunit tmp updates dir to gitignore.

## Addressed issues

- When working on this repo, gdunit constantly reminds me it's out of date and creates a folder that wants to get added to git.