### PR TITLE
Cooldown should save running_child so that its non-ActionLeaf childre…

### DIFF
--- a/addons/beehave/nodes/decorators/cooldown.gd
+++ b/addons/beehave/nodes/decorators/cooldown.gd
@@ -39,9 +39,10 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 			blackboard.set_value("last_condition", c, str(actor.get_instance_id()))
 			blackboard.set_value("last_condition_status", response, str(actor.get_instance_id()))
 
-		if response == RUNNING and c is ActionLeaf:
+		if response == RUNNING:
 			running_child = c
-			blackboard.set_value("running_action", c, str(actor.get_instance_id()))
+			if c is ActionLeaf:
+				blackboard.set_value("running_action", c, str(actor.get_instance_id()))
 
 		if response != RUNNING:
 			blackboard.set_value(cache_key, wait_time, str(actor.get_instance_id()))

--- a/test/actions/mock_action.gd
+++ b/test/actions/mock_action.gd
@@ -1,7 +1,7 @@
 class_name MockAction
 extends ActionLeaf
 
-@export_enum("Success", "Failure") var final_result: int = 0
+@export_enum("Success", "Failure", "Running") var final_result: int = 0
 @export var running_frame_count: int = 0
 
 signal started_running(actor, blackboard)

--- a/test/composites/mock_composite.gd
+++ b/test/composites/mock_composite.gd
@@ -1,0 +1,12 @@
+class_name MockComposite
+extends Composite
+
+@export_enum("Success", "Failure", "Running") var final_result: int = 0
+
+signal interrupted(actor, blackboard)
+
+func interrupt(actor: Node, blackboard: Blackboard) -> void:
+	interrupted.emit(actor, blackboard)
+
+func tick(_actor: Node, _blackboard: Blackboard) -> int:
+	return final_result

--- a/test/nodes/decorators/cooldown_test.gd
+++ b/test/nodes/decorators/cooldown_test.gd
@@ -6,12 +6,14 @@ extends GdUnitTestSuite
 
 # TestSuite generated from
 const __source = "res://addons/beehave/nodes/decorators/cooldown.gd"
-const __action = "res://test/actions/count_up_action.gd"
+const __action = "res://test/actions/mock_action.gd"
+const __composite = "res://test/composites/mock_composite.gd"
 const __tree = "res://addons/beehave/nodes/beehave_tree.gd"
 const __blackboard = "res://addons/beehave/blackboard.gd"
 
 var tree: BeehaveTree
-var action: ActionLeaf
+var action: MockAction
+var composite: MockComposite
 var cooldown: CooldownDecorator
 var runner: GdUnitSceneRunner
 
@@ -19,7 +21,14 @@ var runner: GdUnitSceneRunner
 func before_test() -> void:
 	tree = auto_free(load(__tree).new())
 	action = auto_free(load(__action).new())
+	composite = auto_free(load(__composite).new())
 	cooldown = auto_free(load(__source).new())
+
+	# action setup
+	action.interrupted.connect(_on_interrupted)
+
+	# composite setup
+	composite.interrupted.connect(_on_interrupted)
 
 	var actor = auto_free(Node2D.new())
 	var blackboard = auto_free(load(__blackboard).new())
@@ -32,13 +41,46 @@ func before_test() -> void:
 	runner = scene_runner(tree)
 
 
+func after_test():
+	# resets blackboard
+	tree.blackboard.set_value("interrupted", 0)
+
+
 func test_running_then_fail() -> void:
 	cooldown.wait_time = 1.0
-	action.status = BeehaveNode.RUNNING
+	action.final_result = BeehaveNode.RUNNING
 	assert_that(tree.tick()).is_equal(BeehaveNode.RUNNING)
-	action.status = BeehaveNode.SUCCESS
+	action.final_result = BeehaveNode.SUCCESS
 	assert_that(tree.tick()).is_equal(BeehaveNode.SUCCESS)
-	action.status = BeehaveNode.RUNNING
+	action.final_result = BeehaveNode.RUNNING
 	assert_that(tree.tick()).is_equal(BeehaveNode.FAILURE)
 	await runner.simulate_frames(1, 2000)
 	assert_that(tree.tick()).is_equal(BeehaveNode.RUNNING)
+
+
+func test_interrupt_propagates_when_actionleaf() -> void:
+	cooldown.wait_time = 1.0
+	action.final_result = BeehaveNode.RUNNING
+	tree.tick()
+	tree.interrupt()
+
+	var times_interrupted = tree.blackboard.get_value("interrupted", 0)
+	assert_that(times_interrupted).is_equal(1)
+
+
+func test_interrupt_propagates_when_composite() -> void:
+	cooldown.remove_child(action)
+	cooldown.add_child(composite)
+
+	cooldown.wait_time = 1.0
+	composite.final_result = BeehaveNode.RUNNING
+	tree.tick()
+	tree.interrupt()
+
+	var times_interrupted = tree.blackboard.get_value("interrupted", 0)
+	assert_that(times_interrupted).is_equal(1)
+
+
+func _on_interrupted(_actor, blackboard):
+	var started = blackboard.get_value("interrupted", 0)
+	blackboard.set_value("interrupted", started + 1)


### PR DESCRIPTION
Currently, cooldown.gd does not properly save running_child if it is not an ActionLeaf. This causes interrupt() to not propagate down the tree