### PR TITLE
Move docstrings above class annotations for better Godot editor integration

### DIFF
--- a/addons/beehave/nodes/beehave_node.gd
+++ b/addons/beehave/nodes/beehave_node.gd
@@ -1,8 +1,7 @@
-@tool
-class_name BeehaveNode extends Node
-
 ## A node in the behavior tree. Every node must return `SUCCESS`, `FAILURE` or
 ## `RUNNING` when ticked.
+@tool
+class_name BeehaveNode extends Node
 
 enum { SUCCESS, FAILURE, RUNNING }
 

--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -1,8 +1,7 @@
+## Controls the flow of execution of the entire behavior tree.
 @tool
 @icon("../icons/tree.svg")
 class_name BeehaveTree extends Node
-
-## Controls the flow of execution of the entire behavior tree.
 
 enum { SUCCESS, FAILURE, RUNNING }
 

--- a/addons/beehave/nodes/composites/composite.gd
+++ b/addons/beehave/nodes/composites/composite.gd
@@ -1,8 +1,8 @@
+## A Composite node controls the flow of execution of its children in a specific manner.
 @tool
 @icon("../../icons/category_composite.svg")
 class_name Composite extends BeehaveNode
 
-## A Composite node controls the flow of execution of its children in a specific manner.
 
 var running_child: BeehaveNode = null
 
@@ -30,7 +30,7 @@ func after_run(actor: Node, blackboard: Blackboard) -> void:
 
 
 func get_class_name() -> Array[StringName]:
-	var classes := super()
+	var classes := super ()
 	classes.push_back(&"Composite")
 	return classes
 	

--- a/addons/beehave/nodes/composites/randomized_composite.gd
+++ b/addons/beehave/nodes/composites/randomized_composite.gd
@@ -1,3 +1,7 @@
+## Base class for composite nodes that execute their children in randomized order.
+## Provides functionality for shuffling children with optional weight-based distribution.
+## When weights are enabled, children with higher weights have a higher chance of being
+## selected first in the random ordering.
 @tool
 class_name RandomizedComposite extends Composite
 

--- a/addons/beehave/nodes/composites/selector.gd
+++ b/addons/beehave/nodes/composites/selector.gd
@@ -1,10 +1,8 @@
+## A Selector runs its children in order until one succeeds or is running.
+## On failure, skips already-processed children across ticks.
 @tool
 @icon("../../icons/selector.svg")
 class_name SelectorComposite extends Composite
-
-
-# A Selector runs its children in order until one succeeds or is running.
-# On failure, skips already-processed children across ticks.
 
 
 var last_execution_index: int = 0

--- a/addons/beehave/nodes/composites/selector_random.gd
+++ b/addons/beehave/nodes/composites/selector_random.gd
@@ -1,10 +1,9 @@
-@tool
-@icon("../../icons/selector_random.svg")
-class_name SelectorRandomComposite extends RandomizedComposite
-
 ## This node will attempt to execute all of its children just like a
 ## [code]SelectorStar[/code] would, with the exception that the children
 ## will be executed in a random order.
+@tool
+@icon("../../icons/selector_random.svg")
+class_name SelectorRandomComposite extends RandomizedComposite
 
 ## A shuffled list of the children that will be executed in reverse order.
 var _children_bag: Array[Node] = []

--- a/addons/beehave/nodes/composites/selector_reactive.gd
+++ b/addons/beehave/nodes/composites/selector_reactive.gd
@@ -1,11 +1,10 @@
-@tool
-@icon("../../icons/selector_reactive.svg")
-class_name SelectorReactiveComposite extends Composite
-
 ## Selector Reactive nodes will attempt to execute each of its children until one of
 ## them return `SUCCESS`. If all children return `FAILURE`, this node will also
 ## return `FAILURE`.
 ## If a child returns `RUNNING` it will restart.
+@tool
+@icon("../../icons/selector_reactive.svg")
+class_name SelectorReactiveComposite extends Composite
 
 
 

--- a/addons/beehave/nodes/composites/sequence.gd
+++ b/addons/beehave/nodes/composites/sequence.gd
@@ -1,12 +1,11 @@
-@tool
-@icon("../../icons/sequence.svg")
-class_name SequenceComposite extends Composite
-
 ## Sequence nodes will attempt to execute all of its children and report
 ## `SUCCESS` in case all of the children report a `SUCCESS` status code.
 ## If at least one child reports a `FAILURE` status code, this node will also
 ## return `FAILURE` and restart.
 ## In case a child returns `RUNNING` this node will tick again.
+@tool
+@icon("../../icons/sequence.svg")
+class_name SequenceComposite extends Composite
 
 var successful_index: int = 0
 # Track where we last failed – so we detect a backward jump

--- a/addons/beehave/nodes/composites/sequence_random.gd
+++ b/addons/beehave/nodes/composites/sequence_random.gd
@@ -1,10 +1,9 @@
-@tool
-@icon("../../icons/sequence_random.svg")
-class_name SequenceRandomComposite extends RandomizedComposite
-
 ## This node will attempt to execute all of its children just like a
 ## [code]SequenceStar[/code] would, with the exception that the children
 ## will be executed in a random order.
+@tool
+@icon("../../icons/sequence_random.svg")
+class_name SequenceRandomComposite extends RandomizedComposite
 
 # Emitted whenever the children are shuffled.
 signal reset(new_order: Array[Node])

--- a/addons/beehave/nodes/composites/sequence_reactive.gd
+++ b/addons/beehave/nodes/composites/sequence_reactive.gd
@@ -1,12 +1,12 @@
-@tool
-@icon("../../icons/sequence_reactive.svg")
-class_name SequenceReactiveComposite extends Composite
-
 ## Reactive Sequence nodes will attempt to execute all of its children and report
 ## `SUCCESS` in case all of the children report a `SUCCESS` status code.
 ## If at least one child reports a `FAILURE` status code, this node will also
 ## return `FAILURE` and restart.
 ## In case a child returns `RUNNING` this node will restart.
+@tool
+@icon("../../icons/sequence_reactive.svg")
+class_name SequenceReactiveComposite extends Composite
+
 
 # Track where we last failed – so we detect a backward jump
 var previous_failure_index: int = -1
@@ -67,7 +67,7 @@ func interrupt(actor: Node, blackboard: Blackboard) -> void:
 		running_child.interrupt(actor, blackboard)
 		_cleanup_running(running_child, actor, blackboard)
 	_reset()
-	super(actor, blackboard)
+	super (actor, blackboard)
 
 
 func _reset() -> void:
@@ -76,6 +76,6 @@ func _reset() -> void:
 
 
 func get_class_name() -> Array[StringName]:
-	var classes := super()
+	var classes := super ()
 	classes.push_back(&"SequenceReactiveComposite")
 	return classes

--- a/addons/beehave/nodes/composites/sequence_star.gd
+++ b/addons/beehave/nodes/composites/sequence_star.gd
@@ -1,12 +1,11 @@
-@tool
-@icon("../../icons/sequence_reactive.svg")
-class_name SequenceStarComposite extends Composite
-
 ## Sequence Star nodes will attempt to execute all of its children and report
 ## `SUCCESS` in case all of the children report a `SUCCESS` status code.
 ## If at least one child reports a `FAILURE` status code, this node will also
 ## return `FAILURE` and tick again.
 ## In case a child returns `RUNNING` this node will tick again.
+@tool
+@icon("../../icons/sequence_reactive.svg")
+class_name SequenceStarComposite extends Composite
 
 var successful_index: int = 0
 # Track where we last failed – so we detect a backward jump

--- a/addons/beehave/nodes/composites/simple_parallel.gd
+++ b/addons/beehave/nodes/composites/simple_parallel.gd
@@ -1,7 +1,3 @@
-@tool
-@icon("../../icons/simple_parallel.svg")
-class_name SimpleParallelComposite extends Composite
-
 ## Simple Parallel nodes will attampt to execute all chidren at same time and
 ## can only have exactly two children. First child as primary node, second
 ## child as secondary node.
@@ -12,6 +8,9 @@ class_name SimpleParallelComposite extends Composite
 ## secondary node and return primary node's result.
 ## If this node is running under delay mode, it will wait seconday node
 ## finish its action after primary node terminates.
+@tool
+@icon("../../icons/simple_parallel.svg")
+class_name SimpleParallelComposite extends Composite
 
 #how many times should secondary node repeat, zero means loop forever
 @export var secondary_node_repeat_count: int = 0

--- a/addons/beehave/nodes/decorators/cooldown.gd
+++ b/addons/beehave/nodes/decorators/cooldown.gd
@@ -1,12 +1,11 @@
-@tool
-@icon("../../icons/cooldown.svg")
-extends Decorator
-class_name CooldownDecorator
-
 ## The Cooldown Decorator will return 'FAILURE' for a set amount of time
 ## after executing its child.
 ## The timer resets the next time its child is executed and it is not `RUNNING`
 ## or when the node is interrupted (such as when the behavior tree changes branches).
+@tool
+@icon("../../icons/cooldown.svg")
+extends Decorator
+class_name CooldownDecorator
 
 ## The wait time in seconds
 @export var wait_time := 0.0

--- a/addons/beehave/nodes/decorators/decorator.gd
+++ b/addons/beehave/nodes/decorators/decorator.gd
@@ -1,9 +1,8 @@
+## Decorator nodes are used to transform the result received by its child.
+## Must only have one child.
 @tool
 @icon("../../icons/category_decorator.svg")
 class_name Decorator extends BeehaveNode
-
-## Decorator nodes are used to transform the result received by its child.
-## Must only have one child.
 
 var running_child: BeehaveNode = null
 

--- a/addons/beehave/nodes/decorators/delayer.gd
+++ b/addons/beehave/nodes/decorators/delayer.gd
@@ -1,12 +1,11 @@
-@tool
-@icon("../../icons/delayer.svg")
-extends Decorator
-class_name DelayDecorator
-
 ## The Delay Decorator will return 'RUNNING' for a set amount of time
 ## before executing its child.
 ## The timer resets when both it and its child are not `RUNNING`
 ## or when the node is interrupted (such as when the behavior tree changes branches).
+@tool
+@icon("../../icons/delayer.svg")
+extends Decorator
+class_name DelayDecorator
 
 ## The wait time in seconds
 @export var wait_time := 0.0

--- a/addons/beehave/nodes/decorators/failer.gd
+++ b/addons/beehave/nodes/decorators/failer.gd
@@ -1,8 +1,7 @@
+## A Failer node will always return a `FAILURE` status code.
 @tool
 @icon("../../icons/failer.svg")
 class_name AlwaysFailDecorator extends Decorator
-
-## A Failer node will always return a `FAILURE` status code.
 
 
 func tick(actor: Node, blackboard: Blackboard) -> int:

--- a/addons/beehave/nodes/decorators/inverter.gd
+++ b/addons/beehave/nodes/decorators/inverter.gd
@@ -1,9 +1,8 @@
+## An inverter will return `FAILURE` in case it's child returns a `SUCCESS` status
+## code or `SUCCESS` in case its child returns a `FAILURE` status code.
 @tool
 @icon("../../icons/inverter.svg")
 class_name InverterDecorator extends Decorator
-
-## An inverter will return `FAILURE` in case it's child returns a `SUCCESS` status
-## code or `SUCCESS` in case its child returns a `FAILURE` status code.
 
 
 func tick(actor: Node, blackboard: Blackboard) -> int:

--- a/addons/beehave/nodes/decorators/limiter.gd
+++ b/addons/beehave/nodes/decorators/limiter.gd
@@ -1,11 +1,10 @@
-@tool
-@icon("../../icons/limiter.svg")
-class_name LimiterDecorator extends Decorator
-
 ## The limiter will execute its `RUNNING` child `x` amount of times. When the number of
 ## maximum ticks is reached, it will return a `FAILURE` status code.
 ## The count resets the next time that a child is not `RUNNING`
 ## or when the node is interrupted (such as when the behavior tree changes branches).
+@tool
+@icon("../../icons/limiter.svg")
+class_name LimiterDecorator extends Decorator
 
 @onready var cache_key = "limiter_%s" % self.get_instance_id()
 

--- a/addons/beehave/nodes/decorators/succeeder.gd
+++ b/addons/beehave/nodes/decorators/succeeder.gd
@@ -1,8 +1,7 @@
+## A succeeder node will always return a `SUCCESS` status code.
 @tool
 @icon("../../icons/succeeder.svg")
 class_name AlwaysSucceedDecorator extends Decorator
-
-## A succeeder node will always return a `SUCCESS` status code.
 
 
 func tick(actor: Node, blackboard: Blackboard) -> int:

--- a/addons/beehave/nodes/decorators/time_limiter.gd
+++ b/addons/beehave/nodes/decorators/time_limiter.gd
@@ -1,11 +1,10 @@
-@tool
-@icon("../../icons/limiter.svg")
-class_name TimeLimiterDecorator extends Decorator
-
 ## The Time Limit Decorator will give its `RUNNING` child a set amount of time to finish
 ## before interrupting it and return a `FAILURE` status code.
 ## The timer resets the next time that a child is not `RUNNING`
 ## or when the node is interrupted (such as when the behavior tree changes branches).
+@tool
+@icon("../../icons/limiter.svg")
+class_name TimeLimiterDecorator extends Decorator
 
 @export var wait_time := 0.0
 

--- a/addons/beehave/nodes/decorators/until_fail.gd
+++ b/addons/beehave/nodes/decorators/until_fail.gd
@@ -1,11 +1,10 @@
+## The UntilFail Decorator will return `RUNNING` if its child returns
+## `SUCCESS` or `RUNNING` or it will return `SUCCESS` if its child returns
+## `FAILURE`
 @tool
 @icon("../../icons/until_fail.svg")
 class_name UntilFailDecorator
 extends Decorator
-
-## The UntilFail Decorator will return `RUNNING` if its child returns
-## `SUCCESS` or `RUNNING` or it will return `SUCCESS` if its child returns
-## `FAILURE`
 
 
 func tick(actor: Node, blackboard: Blackboard) -> int:

--- a/addons/beehave/nodes/leaves/action.gd
+++ b/addons/beehave/nodes/leaves/action.gd
@@ -1,11 +1,10 @@
-@tool
-@icon("../../icons/action.svg")
-class_name ActionLeaf extends Leaf
-
 ## Actions are leaf nodes that define a task to be performed by an actor.
 ## Their execution can be long running, potentially being called across multiple
 ## frame executions. In this case, the node should return `RUNNING` until the
 ## action is completed.
+@tool
+@icon("../../icons/action.svg")
+class_name ActionLeaf extends Leaf
 
 
 func get_class_name() -> Array[StringName]:

--- a/addons/beehave/nodes/leaves/blackboard_compare.gd
+++ b/addons/beehave/nodes/leaves/blackboard_compare.gd
@@ -1,9 +1,8 @@
-@tool
-class_name BlackboardCompareCondition extends ConditionLeaf
-
 ## Compares two values using the specified comparison operator.
 ## Returns [code]FAILURE[/code] if any of the expression fails or the
 ## comparison operation returns [code]false[/code], otherwise it returns [code]SUCCESS[/code].
+@tool
+class_name BlackboardCompareCondition extends ConditionLeaf
 
 enum Operators {
 	EQUAL,

--- a/addons/beehave/nodes/leaves/blackboard_erase.gd
+++ b/addons/beehave/nodes/leaves/blackboard_erase.gd
@@ -1,8 +1,7 @@
-@tool
-class_name BlackboardEraseAction extends ActionLeaf
-
 ## Erases the specified key from the blackboard.
 ## Returns [code]FAILURE[/code] if expression execution fails, otherwise [code]SUCCESS[/code].
+@tool
+class_name BlackboardEraseAction extends ActionLeaf
 
 ## Expression representing a blackboard key.
 @export_placeholder(EXPRESSION_PLACEHOLDER) var key: String = ""

--- a/addons/beehave/nodes/leaves/blackboard_has.gd
+++ b/addons/beehave/nodes/leaves/blackboard_has.gd
@@ -1,8 +1,7 @@
-@tool
-class_name BlackboardHasCondition extends ConditionLeaf
-
 ## Returns [code]FAILURE[/code] if expression execution fails or the specified key doesn't exist.
 ## Returns [code]SUCCESS[/code] if blackboard has the specified key.
+@tool
+class_name BlackboardHasCondition extends ConditionLeaf
 
 ## Expression representing a blackboard key.
 @export_placeholder(EXPRESSION_PLACEHOLDER) var key: String = ""

--- a/addons/beehave/nodes/leaves/blackboard_set.gd
+++ b/addons/beehave/nodes/leaves/blackboard_set.gd
@@ -1,8 +1,7 @@
-@tool
-class_name BlackboardSetAction extends ActionLeaf
-
 ## Sets the specified key to the specified value.
 ## Returns [code]FAILURE[/code] if expression execution fails, otherwise [code]SUCCESS[/code].
+@tool
+class_name BlackboardSetAction extends ActionLeaf
 
 ## Expression representing a blackboard key.
 @export_placeholder(EXPRESSION_PLACEHOLDER) var key: String = ""

--- a/addons/beehave/nodes/leaves/condition.gd
+++ b/addons/beehave/nodes/leaves/condition.gd
@@ -1,9 +1,8 @@
+## Conditions are leaf nodes that either return SUCCESS or FAILURE depending on
+## a single simple condition. They should never return `RUNNING`.
 @tool
 @icon("../../icons/condition.svg")
 class_name ConditionLeaf extends Leaf
-
-## Conditions are leaf nodes that either return SUCCESS or FAILURE depending on
-## a single simple condition. They should never return `RUNNING`.
 
 
 func get_class_name() -> Array[StringName]:

--- a/addons/beehave/nodes/leaves/leaf.gd
+++ b/addons/beehave/nodes/leaves/leaf.gd
@@ -1,8 +1,7 @@
+## Base class for all leaf nodes of the tree.
 @tool
 @icon("../../icons/category_leaf.svg")
 class_name Leaf extends BeehaveNode
-
-## Base class for all leaf nodes of the tree.
 
 const EXPRESSION_PLACEHOLDER: String = "Insert an expression..."
 


### PR DESCRIPTION
Repositioned all class-level docstrings to appear before @tool, @icon, and class_name annotations across all behavior tree node files, and added missing docstring to
  RandomizedComposite.

  Why this change was needed

  In Godot 4.x, the "Create Node" dialog window displays class documentation to help developers understand what each node does before adding it to their scene. However, Godot's
  documentation parser only recognizes docstrings that appear before the class annotations, not after them.

  What was changed

  - 23+ node files had their docstrings moved from after the annotations to before them
  - 1 file (randomized_composite.gd) had a missing docstring added
  - 1 file (selector.gd) had single # comments converted to proper ## docstrings

  Example of the change

  Before:
```gdscript
  @tool
  @icon("../../icons/sequence_reactive.svg")
  class_name SequenceReactiveComposite extends Composite

  ## Reactive Sequence nodes will attempt to execute all of its children and report
  ## `SUCCESS` in case all of the children report a `SUCCESS` status code.
```
  After:
```gdscript
  ## Reactive Sequence nodes will attempt to execute all of its children and report
  ## `SUCCESS` in case all of the children report a `SUCCESS` status code.
  @tool
  @icon("../../icons/sequence_reactive.svg")
  class_name SequenceReactiveComposite extends Composite
```
  User benefit

  Now when developers use Godot's "Create Node" dialog (Ctrl+A), they'll see helpful descriptions for each Beehave node type, making it much easier to understand what each node does     
   before adding it to their behavior tree. This significantly improves the developer experience and reduces the need to look up documentation separately.

  Files affected

  All node files in addons/beehave/nodes/ including composites (selectors, sequences, parallel), decorators (cooldown, limiter, inverter, etc.), and leaves (actions, conditions,
  blackboard operations).