### PR TITLE
Add tree tick_mode

### DIFF
--- a/addons/beehave/nodes/beehave_tree.gd
+++ b/addons/beehave/nodes/beehave_tree.gd
@@ -6,6 +6,7 @@ class_name BeehaveTree extends Node
 enum { SUCCESS, FAILURE, RUNNING }
 
 enum ProcessThread { IDLE, PHYSICS, MANUAL }
+enum TickMode { BOTH, PROCESS, PHYSICS, MANUAL }
 
 signal tree_enabled
 signal tree_disabled
@@ -24,6 +25,10 @@ signal tree_disabled
 
 	get:
 		return enabled
+
+## How automatic ticking of the tree should be handled. The default is to
+## tick on both _process and _physics_process.
+@export var tick_mode: TickMode = TickMode.BOTH
 
 ## How often the tree should tick, in frames. The default value of 1 means
 ## tick() runs every frame.
@@ -164,11 +169,13 @@ func _on_scene_tree_node_added_removed(node: Node, is_added: bool) -> void:
 
 
 func _physics_process(_delta: float) -> void:
-	tick()
+	if tick_mode == TickMode.BOTH or tick_mode == TickMode.PHYSICS:
+		tick()
 
 
 func _process(_delta: float) -> void:
-	tick()
+	if tick_mode == TickMode.BOTH or tick_mode == TickMode.PROCESS:
+		tick()
 
 
 func tick() -> int:
@@ -202,13 +209,13 @@ func tick() -> int:
 	if status != RUNNING:
 		blackboard.set_value("running_action", null, str(actor.get_instance_id()))
 		child.after_run(actor, blackboard)
-		
+
 	if _can_send_message and not Engine.is_editor_hint():
 		BeehaveDebuggerMessages.process_end(get_instance_id(), blackboard.get_debug_data())
 
 	# Check the cost for this frame and save it for metric report
 	_process_time_metric_value = Time.get_ticks_usec() - start_time
-	
+
 	return status
 
 

--- a/test/beehave_tree_test.gd
+++ b/test/beehave_tree_test.gd
@@ -22,6 +22,33 @@ func test_normal_tick() -> void:
 	scene.beehave_tree._physics_process(1.0)
 	assert_that(scene.beehave_tree.status).is_equal(BeehaveNode.SUCCESS)
 
+func test_process_tick() -> void:
+	var scene = create_scene()
+	scene_runner(scene)
+	scene.beehave_tree.tick_mode = scene.beehave_tree.TickMode.PROCESS
+	scene.beehave_tree._physics_process(1.0)
+	assert_that(scene.beehave_tree.status).is_equal(-1)
+	scene.beehave_tree._process(1.0)
+	assert_that(scene.beehave_tree.status).is_equal(BeehaveNode.SUCCESS)
+
+func test_physics_process_tick() -> void:
+	var scene = create_scene()
+	scene_runner(scene)
+	scene.beehave_tree.tick_mode = scene.beehave_tree.TickMode.PHYSICS
+	scene.beehave_tree._process(1.0)
+	assert_that(scene.beehave_tree.status).is_equal(-1)
+	scene.beehave_tree._physics_process(1.0)
+	assert_that(scene.beehave_tree.status).is_equal(BeehaveNode.SUCCESS)
+
+func test_manual_tick() -> void:
+	var scene = create_scene()
+	scene_runner(scene)
+	scene.beehave_tree.tick_mode = scene.beehave_tree.TickMode.MANUAL
+	scene.beehave_tree._process(1.0)
+	scene.beehave_tree._physics_process(1.0)
+	assert_that(scene.beehave_tree.status).is_equal(-1)
+	scene.beehave_tree.tick()
+	assert_that(scene.beehave_tree.status).is_equal(BeehaveNode.SUCCESS)
 
 func test_low_tick_rate() -> void:
 	var scene = create_scene()
@@ -121,11 +148,11 @@ func test_manual_mode_does_not_auto_tick() -> void:
 	scene_runner(scene)
 	scene.beehave_tree.process_thread = BeehaveTree.ProcessThread.MANUAL
 	scene.beehave_tree.enabled = true
-	
+
 	# Set up count up action
 	scene.count_up_action.status = BeehaveNode.RUNNING
 	scene.beehave_tree.blackboard.set_value("custom_value", 0)
-	
+
 	# Wait a bit to verify no auto-ticks
 	await get_tree().create_timer(0.1).timeout
 	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(0)
@@ -136,15 +163,15 @@ func test_manual_mode_can_tick_manually() -> void:
 	scene_runner(scene)
 	scene.beehave_tree.process_thread = BeehaveTree.ProcessThread.MANUAL
 	scene.beehave_tree.enabled = true
-	
+
 	# Set up count up action
 	scene.count_up_action.status = BeehaveNode.RUNNING
 	scene.beehave_tree.blackboard.set_value("custom_value", 0)
-	
+
 	# Manual tick should increase counter
 	scene.beehave_tree.tick()
 	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(1)
-	
+
 	# Another manual tick should increase counter again
 	scene.beehave_tree.tick()
 	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(2)
@@ -156,23 +183,23 @@ func test_manual_mode_respects_tick_rate() -> void:
 	scene.beehave_tree.process_thread = BeehaveTree.ProcessThread.MANUAL
 	scene.beehave_tree.tick_rate = 3
 	scene.beehave_tree.enabled = true
-	
+
 	# Set up count up action
 	scene.count_up_action.status = BeehaveNode.RUNNING
 	scene.beehave_tree.blackboard.set_value("custom_value", 0)
-	
+
 	# First tick should increase counter
 	scene.beehave_tree.tick()
 	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(1)
-	
-	# Second tick should not yet increase counter 
+
+	# Second tick should not yet increase counter
 	scene.beehave_tree.tick()
 	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(1)
-	
-	# Second tick should not yet increase counter 
+
+	# Second tick should not yet increase counter
 	scene.beehave_tree.tick()
 	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(1)
-	
+
 	# Fourth tick should increase counter
 	scene.beehave_tree.tick()
 	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(2)
@@ -183,25 +210,25 @@ func test_manual_mode_can_be_disabled() -> void:
 	scene_runner(scene)
 	scene.beehave_tree.process_thread = BeehaveTree.ProcessThread.MANUAL
 	scene.beehave_tree.enabled = true
-	
+
 	# Set up count up action
 	scene.count_up_action.status = BeehaveNode.RUNNING
 	scene.beehave_tree.blackboard.set_value("custom_value", 0)
-	
+
 	# Should be able to tick when enabled
 	scene.beehave_tree.tick()
 	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(1)
-	
+
 	# Disable the tree
 	scene.beehave_tree.disable()
-	
+
 	# Should not be able to tick when disabled
 	scene.beehave_tree.tick()
 	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(1)  # Value should not change
-	
+
 	# Re-enable the tree
 	scene.beehave_tree.enable()
-	
+
 	# Should be able to tick again
 	scene.beehave_tree.tick()
 	assert_that(scene.beehave_tree.blackboard.get_value("custom_value")).is_equal(2)


### PR DESCRIPTION
## Description

This PR adds a `tick_mode` option to `BeehaveTree` with the following options:
- `BOTH` - ticks on `_process` and `_physics_process`
- `PROCESS` - ticks on `_process`
- `PHYSICS` - ticks on `_physics_process`
- `MANUAL` - doesn't tick at all. Call `$YourTree.tick()` to tick the tree.

This PR is backwards compatible as it defaults to `BOTH` which is the existing functionality. Existing trees will continue working exactly as they always have.

There are a couple of reasons for this change:
- I want to be able to tick some trees at my own custom rate. The `tick_rate` option kind of accomplishes this but setting to `MANUAL` offers the ultimate in flexibility and let's the developer decide exactly how and when the tree ticks
- The current default of `BOTH` is kind of dangerous and your unit tests don't cover this. `_process` runs an unknown number of times per second so `tick_rate` isn't reliable.

Fixes #389


