### PR TITLE
upgrade deps to Godot 4.7

### DIFF
--- a/.github/workflows/beehave-ci.yml
+++ b/.github/workflows/beehave-ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ["4.5.1", "4.6"]
+        godot-version: ["4.5.1", "4.6.3", "4.7"]
 
     name: "🤖 CI on Godot ${{ matrix.godot-version }}"
     steps:
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run GDUnit4 tests
-        uses: MikeSchulze/gdUnit4-action@v1.3.0
+        uses: MikeSchulze/gdUnit4-action@v1.3.2
         with:
           godot-version: ${{ matrix.godot-version }}
           godot-status: "stable"

--- a/addons/beehave/nodes/composites/simple_parallel.gd
+++ b/addons/beehave/nodes/composites/simple_parallel.gd
@@ -33,7 +33,7 @@ func _get_configuration_warnings() -> PackedStringArray:
 	return warnings
 
 
-func tick(actor, blackboard: Blackboard):
+func tick(actor: Node, blackboard: Blackboard) -> int:
 	for c in get_children():
 		var node_index: int = c.get_index()
 		if node_index == 0 and not main_task_finished:

--- a/addons/beehave/nodes/decorators/repeater.gd
+++ b/addons/beehave/nodes/decorators/repeater.gd
@@ -10,7 +10,7 @@ class_name RepeaterDecorator extends Decorator
 var current_count: int = 0
 
 
-func before_run(actor: Node, blackboard: Blackboard):
+func before_run(actor: Node, blackboard: Blackboard) -> void:
 	current_count = 0
 
 

--- a/addons/gdUnit4/GdUnitRunner.cfg
+++ b/addons/gdUnit4/GdUnitRunner.cfg
@@ -9,11 +9,9 @@
 			"attribute_index": -1,
 			"display_name": "test_normal_tick",
 			"fully_qualified_name": "test.beehave_tree_test.test_normal_tick",
-			"guid": "34717ab8-f10b487-7942267-00937fc402",
+			"guid": "8b75afa1-d09e43a-897f777-5c626fed17",
 			"line_number": 19,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -27,11 +25,9 @@
 			"attribute_index": -1,
 			"display_name": "test_low_tick_rate",
 			"fully_qualified_name": "test.beehave_tree_test.test_low_tick_rate",
-			"guid": "e1cfd915-51b444f-daf4138-56a89484d6",
+			"guid": "977ff98e-ce3f481-5ab233f-8691bb04f4",
 			"line_number": 26,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -45,11 +41,9 @@
 			"attribute_index": -1,
 			"display_name": "test_low_tick_rate_last_tick",
 			"fully_qualified_name": "test.beehave_tree_test.test_low_tick_rate_last_tick",
-			"guid": "fe8961ba-4296440-fbe1be6-40206088fc",
+			"guid": "3e3746cd-4f5945f-3825acf-dcff3e7956",
 			"line_number": 39,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -63,11 +57,9 @@
 			"attribute_index": -1,
 			"display_name": "test_nothing_running_before_first_tick",
 			"fully_qualified_name": "test.beehave_tree_test.test_nothing_running_before_first_tick",
-			"guid": "d740d27b-03a2420-0b25cb6-2e7d77d217",
+			"guid": "96a1b3b8-606c4cd-5995a5d-e7089b7bed",
 			"line_number": 50,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -81,11 +73,9 @@
 			"attribute_index": -1,
 			"display_name": "test_get_last_condition",
 			"fully_qualified_name": "test.beehave_tree_test.test_get_last_condition",
-			"guid": "0bbf1899-09ff45d-88b7453-2b3bf82975",
+			"guid": "9d6b1a5a-cda74dc-f808baf-8d818b9759",
 			"line_number": 58,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -99,11 +89,9 @@
 			"attribute_index": -1,
 			"display_name": "test_disabled",
 			"fully_qualified_name": "test.beehave_tree_test.test_disabled",
-			"guid": "41ef4389-359a4d4-c8ae226-483050407e",
+			"guid": "2a5901f1-781744a-5b3a7f1-ff4f85b17a",
 			"line_number": 67,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -117,11 +105,9 @@
 			"attribute_index": -1,
 			"display_name": "test_reenabled",
 			"fully_qualified_name": "test.beehave_tree_test.test_reenabled",
-			"guid": "ebb40e09-b771435-3ab574f-717f00e723",
+			"guid": "bd35f514-8c28466-9afda60-88d33fd20c",
 			"line_number": 77,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -135,11 +121,9 @@
 			"attribute_index": -1,
 			"display_name": "test_interrupt_running_action",
 			"fully_qualified_name": "test.beehave_tree_test.test_interrupt_running_action",
-			"guid": "a01bca80-93b4432-aa8e4d8-aef2ed9d38",
+			"guid": "257c3906-e4cc43f-49cbd06-1743b77000",
 			"line_number": 87,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -153,11 +137,9 @@
 			"attribute_index": -1,
 			"display_name": "test_blackboard_not_initialized",
 			"fully_qualified_name": "test.beehave_tree_test.test_blackboard_not_initialized",
-			"guid": "703b034e-35cc4fc-785888c-713ebcb5a9",
+			"guid": "891ffcfb-8685462-39c3ffe-f9d655da74",
 			"line_number": 99,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -171,11 +153,9 @@
 			"attribute_index": -1,
 			"display_name": "test_actor_override",
 			"fully_qualified_name": "test.beehave_tree_test.test_actor_override",
-			"guid": "cab5802e-a0f64aa-9860a91-cf099b7023",
+			"guid": "e784a0da-a57e433-b8c9ca2-df4185e617",
 			"line_number": 109,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -189,11 +169,9 @@
 			"attribute_index": -1,
 			"display_name": "test_manual_mode_does_not_auto_tick",
 			"fully_qualified_name": "test.beehave_tree_test.test_manual_mode_does_not_auto_tick",
-			"guid": "0c1a6362-e5df4bd-6ace1d6-e524089ff0",
+			"guid": "de894fbe-7b5b4e7-58c9079-5212378065",
 			"line_number": 119,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -207,11 +185,9 @@
 			"attribute_index": -1,
 			"display_name": "test_manual_mode_can_tick_manually",
 			"fully_qualified_name": "test.beehave_tree_test.test_manual_mode_can_tick_manually",
-			"guid": "08e43f69-e90e480-dad613d-eb19480c12",
+			"guid": "b04ee6e5-77dc4a7-1adab8e-e68177e852",
 			"line_number": 134,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -225,11 +201,9 @@
 			"attribute_index": -1,
 			"display_name": "test_manual_mode_respects_tick_rate",
 			"fully_qualified_name": "test.beehave_tree_test.test_manual_mode_respects_tick_rate",
-			"guid": "2f35bf27-03954bd-f8060ef-08c9f07a98",
+			"guid": "7d32260e-56aa4b3-cb94221-f81433ae10",
 			"line_number": 153,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -243,11 +217,9 @@
 			"attribute_index": -1,
 			"display_name": "test_manual_mode_can_be_disabled",
 			"fully_qualified_name": "test.beehave_tree_test.test_manual_mode_can_be_disabled",
-			"guid": "a5ac58f0-540643c-cbe3186-8d0bdce439",
+			"guid": "e72f5d28-4f69498-9bb4954-9de5e51c89",
 			"line_number": 181,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/beehave_tree_test.gd",
 			"suite_name": "beehave_tree_test",
@@ -261,11 +233,9 @@
 			"attribute_index": -1,
 			"display_name": "test_action_after_run",
 			"fully_qualified_name": "test.before_after_run_test.test_action_after_run",
-			"guid": "adf8cae4-5fc8412-6a6a7d2-6f8e0b427f",
+			"guid": "0f5b3589-596b4ee-1b93ff2-bcd07c714d",
 			"line_number": 30,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/before_after_run_test.gd",
 			"suite_name": "before_after_run_test",
@@ -279,11 +249,9 @@
 			"attribute_index": -1,
 			"display_name": "test_has_value",
 			"fully_qualified_name": "test.blackboard.blackboard_test.test_has_value",
-			"guid": "05583f56-ff0642b-bbf1e3f-e6d98bf175",
+			"guid": "7d8e360c-707645e-d8b3d8b-156b6e1efa",
 			"line_number": 11,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/blackboard/blackboard_test.gd",
 			"suite_name": "blackboard_test",
@@ -297,11 +265,9 @@
 			"attribute_index": -1,
 			"display_name": "test_erase_value",
 			"fully_qualified_name": "test.blackboard.blackboard_test.test_erase_value",
-			"guid": "55fdd22f-3371413-88b7bcb-da8c414496",
+			"guid": "15b49065-a0ee45b-b8a1299-f80829f1d1",
 			"line_number": 18,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/blackboard/blackboard_test.gd",
 			"suite_name": "blackboard_test",
@@ -315,11 +281,9 @@
 			"attribute_index": -1,
 			"display_name": "test_separate_blackboard_erase_value",
 			"fully_qualified_name": "test.blackboard.blackboard_test.test_separate_blackboard_erase_value",
-			"guid": "6b918425-566241e-eb95723-123779f30c",
+			"guid": "93823649-7465474-19c8341-46e8e949d4",
 			"line_number": 25,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/blackboard/blackboard_test.gd",
 			"suite_name": "blackboard_test",
@@ -333,11 +297,9 @@
 			"attribute_index": -1,
 			"display_name": "test_set_value",
 			"fully_qualified_name": "test.blackboard.blackboard_test.test_set_value",
-			"guid": "256542b7-ccf2419-3944644-39c6b06cda",
+			"guid": "060da6e5-574a41d-e967fab-1c0cf751f5",
 			"line_number": 32,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/blackboard/blackboard_test.gd",
 			"suite_name": "blackboard_test",
@@ -351,11 +313,9 @@
 			"attribute_index": -1,
 			"display_name": "test_separate_blackboard_id_value",
 			"fully_qualified_name": "test.blackboard.blackboard_test.test_separate_blackboard_id_value",
-			"guid": "1e82c85b-524143d-29d15b3-a9bc919d11",
+			"guid": "76b1e35d-42ab4d4-eb651b2-1ba61c225c",
 			"line_number": 38,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/blackboard/blackboard_test.gd",
 			"suite_name": "blackboard_test",
@@ -369,11 +329,9 @@
 			"attribute_index": -1,
 			"display_name": "test_get_default",
 			"fully_qualified_name": "test.blackboard.blackboard_test.test_get_default",
-			"guid": "4afbe0aa-4b254f2-69ae4e5-258058b749",
+			"guid": "16444fba-e96e4df-a94948e-99966c68f7",
 			"line_number": 46,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/blackboard/blackboard_test.gd",
 			"suite_name": "blackboard_test",
@@ -387,11 +345,9 @@
 			"attribute_index": -1,
 			"display_name": "test_blackboard_shared_between_trees",
 			"fully_qualified_name": "test.blackboard.blackboard_test.test_blackboard_shared_between_trees",
-			"guid": "d68a1252-650e40e-08bb25c-25c76f5262",
+			"guid": "99fd9208-7b414d7-da1d007-3310dfb261",
 			"line_number": 52,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/blackboard/blackboard_test.gd",
 			"suite_name": "blackboard_test",
@@ -405,11 +361,9 @@
 			"attribute_index": -1,
 			"display_name": "test_blackboard_property_shared_between_trees",
 			"fully_qualified_name": "test.blackboard.blackboard_test.test_blackboard_property_shared_between_trees",
-			"guid": "eb83fb5b-5bbf488-caf3f06-cf4767ef0e",
+			"guid": "e704788e-79534d4-5a29199-8f3f0558dc",
 			"line_number": 63,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/blackboard/blackboard_test.gd",
 			"suite_name": "blackboard_test",
@@ -423,11 +377,9 @@
 			"attribute_index": -1,
 			"display_name": "test_separate_blackboards_independent_values",
 			"fully_qualified_name": "test.blackboard.blackboard_test.test_separate_blackboards_independent_values",
-			"guid": "0bc3ec11-147e4e5-dbeac98-698817e700",
+			"guid": "82f62023-044b49a-7ac03f5-b07fcc2e1b",
 			"line_number": 76,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/blackboard/blackboard_test.gd",
 			"suite_name": "blackboard_test",
@@ -441,11 +393,9 @@
 			"attribute_index": -1,
 			"display_name": "test_debugger_renders_correctly",
 			"fully_qualified_name": "test.debug.debugger_test.test_debugger_renders_correctly",
-			"guid": "7bbe8d7e-d19845b-2a3873d-f30c8cb688",
+			"guid": "f9985c81-d1c9441-8857c11-9db91313e8",
 			"line_number": 16,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/debug/debugger_test.gd",
 			"suite_name": "debugger_test",
@@ -459,11 +409,9 @@
 			"attribute_index": -1,
 			"display_name": "test_changing_to_all_colors",
 			"fully_qualified_name": "test.e2e_test.test_changing_to_all_colors",
-			"guid": "f9b1f3cc-3e9a447-58854df-2d6a2d59ee",
+			"guid": "44f6bbc8-975c46c-e813681-cfce87be88",
 			"line_number": 15,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/e2e_test.gd",
 			"suite_name": "e2e_test",
@@ -477,11 +425,9 @@
 			"attribute_index": -1,
 			"display_name": "test_always_executing_first_successful_node",
 			"fully_qualified_name": "test.nodes.composites.selector_random_test.test_always_executing_first_successful_node",
-			"guid": "996d4da5-bc0e40f-681cd84-ea7c7ff22a",
+			"guid": "b1cf044e-99274ed-cb3c1a2-defc7d7327",
 			"line_number": 38,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_random_test.gd",
 			"suite_name": "selector_random_test",
@@ -495,11 +441,9 @@
 			"attribute_index": -1,
 			"display_name": "test_execute_second_when_first_is_failing",
 			"fully_qualified_name": "test.nodes.composites.selector_random_test.test_execute_second_when_first_is_failing",
-			"guid": "84d076a6-7b85422-49f5878-4aae4d73a1",
+			"guid": "547c4a59-77c6479-f9db2e2-bbe426b8ae",
 			"line_number": 46,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_random_test.gd",
 			"suite_name": "selector_random_test",
@@ -513,11 +457,9 @@
 			"attribute_index": -1,
 			"display_name": "test_random_even_execution",
 			"fully_qualified_name": "test.nodes.composites.selector_random_test.test_random_even_execution",
-			"guid": "8db67dae-d8e24aa-6874554-e94320c274",
+			"guid": "e8b7664d-347641b-492e7d9-ad7978927c",
 			"line_number": 55,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_random_test.gd",
 			"suite_name": "selector_random_test",
@@ -531,11 +473,9 @@
 			"attribute_index": -1,
 			"display_name": "test_return_failure_of_none_is_succeeding",
 			"fully_qualified_name": "test.nodes.composites.selector_random_test.test_return_failure_of_none_is_succeeding",
-			"guid": "1971f998-ac64456-2aa10ec-835af81d0c",
+			"guid": "0cb26d5d-e031454-195370f-72f4d6f396",
 			"line_number": 63,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_random_test.gd",
 			"suite_name": "selector_random_test",
@@ -549,11 +489,9 @@
 			"attribute_index": -1,
 			"display_name": "test_clear_running_child_after_run",
 			"fully_qualified_name": "test.nodes.composites.selector_random_test.test_clear_running_child_after_run",
-			"guid": "1eade657-df64480-9ae81b3-fdecbb688d",
+			"guid": "ce58b4e6-c563493-7846c8f-9b7944aaff",
 			"line_number": 72,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_random_test.gd",
 			"suite_name": "selector_random_test",
@@ -567,11 +505,9 @@
 			"attribute_index": -1,
 			"display_name": "test_always_executing_first_successful_node",
 			"fully_qualified_name": "test.nodes.composites.selector_reactive_test.test_always_executing_first_successful_node",
-			"guid": "3aa751b0-235f489-79344c4-eb23ad6454",
+			"guid": "22d6918d-3085438-7b50ffc-4b5626af26",
 			"line_number": 38,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_reactive_test.gd",
 			"suite_name": "selector_reactive_test",
@@ -585,11 +521,9 @@
 			"attribute_index": -1,
 			"display_name": "test_execute_second_when_first_is_failing",
 			"fully_qualified_name": "test.nodes.composites.selector_reactive_test.test_execute_second_when_first_is_failing",
-			"guid": "e3322938-ce004d1-9b608f6-3e8f50e119",
+			"guid": "d38cc576-f04a4f5-2861790-d51cbcd40a",
 			"line_number": 48,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_reactive_test.gd",
 			"suite_name": "selector_reactive_test",
@@ -603,11 +537,9 @@
 			"attribute_index": -1,
 			"display_name": "test_return_failure_of_none_is_succeeding",
 			"fully_qualified_name": "test.nodes.composites.selector_reactive_test.test_return_failure_of_none_is_succeeding",
-			"guid": "597d17db-85eb4f2-9a138b6-4bc6d51922",
+			"guid": "33000c10-a0de411-9a59976-a26e99f09c",
 			"line_number": 61,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_reactive_test.gd",
 			"suite_name": "selector_reactive_test",
@@ -621,11 +553,9 @@
 			"attribute_index": -1,
 			"display_name": "test_keeps_restarting_child_until_success",
 			"fully_qualified_name": "test.nodes.composites.selector_reactive_test.test_keeps_restarting_child_until_success",
-			"guid": "1602c57f-3fb8429-99b4d2a-73f92c08f1",
+			"guid": "8867f4cb-2bfd4b6-f9c7484-72e15a9cd3",
 			"line_number": 71,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_reactive_test.gd",
 			"suite_name": "selector_reactive_test",
@@ -639,11 +569,9 @@
 			"attribute_index": -1,
 			"display_name": "test_keeps_restarting_child_until_failure",
 			"fully_qualified_name": "test.nodes.composites.selector_reactive_test.test_keeps_restarting_child_until_failure",
-			"guid": "22827237-b4574ba-9b6f660-5d2b6d41a7",
+			"guid": "ea0e32de-d00647a-4a19ffb-6e2270af6e",
 			"line_number": 92,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_reactive_test.gd",
 			"suite_name": "selector_reactive_test",
@@ -657,11 +585,9 @@
 			"attribute_index": -1,
 			"display_name": "test_interrupt_second_when_first_is_running",
 			"fully_qualified_name": "test.nodes.composites.selector_reactive_test.test_interrupt_second_when_first_is_running",
-			"guid": "f8d1d0ac-cc71456-6a81e77-a95d0253b5",
+			"guid": "44930197-6a39450-b87203a-fd4e255fc3",
 			"line_number": 113,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_reactive_test.gd",
 			"suite_name": "selector_reactive_test",
@@ -675,11 +601,9 @@
 			"attribute_index": -1,
 			"display_name": "test_clear_running_child_after_run",
 			"fully_qualified_name": "test.nodes.composites.selector_reactive_test.test_clear_running_child_after_run",
-			"guid": "6bdf3cb8-1c4f4f6-d810114-4e31c6c82d",
+			"guid": "09b3011c-963b45c-d818fc9-c90d30f7b4",
 			"line_number": 126,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_reactive_test.gd",
 			"suite_name": "selector_reactive_test",
@@ -693,11 +617,9 @@
 			"attribute_index": -1,
 			"display_name": "test_branch_change_detection",
 			"fully_qualified_name": "test.nodes.composites.selector_reactive_test.test_branch_change_detection",
-			"guid": "2a568094-b8444f0-fb8d031-ea28b7c5cf",
+			"guid": "86b2e1fb-97c44bd-8a4ca8e-8f318fed57",
 			"line_number": 136,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_reactive_test.gd",
 			"suite_name": "selector_reactive_test",
@@ -711,11 +633,9 @@
 			"attribute_index": -1,
 			"display_name": "test_complex_nested_selector_interruption",
 			"fully_qualified_name": "test.nodes.composites.selector_reactive_test.test_complex_nested_selector_interruption",
-			"guid": "ea914681-8cc4418-d95f355-43b9b401d4",
+			"guid": "ccc920fd-c5a2451-6891eea-6ff4c94cbf",
 			"line_number": 171,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_reactive_test.gd",
 			"suite_name": "selector_reactive_test",
@@ -729,11 +649,9 @@
 			"attribute_index": -1,
 			"display_name": "test_interrupt_all_children_after_all_failed",
 			"fully_qualified_name": "test.nodes.composites.selector_reactive_test.test_interrupt_all_children_after_all_failed",
-			"guid": "6203eccf-9aff496-f91d9ac-597b1e08ad",
+			"guid": "dc9c8d5d-9efd47b-280b8a8-4bd4a4964b",
 			"line_number": 245,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_reactive_test.gd",
 			"suite_name": "selector_reactive_test",
@@ -747,11 +665,9 @@
 			"attribute_index": -1,
 			"display_name": "test_nested_interrupt_after_all_failed",
 			"fully_qualified_name": "test.nodes.composites.selector_reactive_test.test_nested_interrupt_after_all_failed",
-			"guid": "f3a48dd8-136b436-19233c3-f6219a996f",
+			"guid": "41c9708c-f52e4f9-eb349ed-21ef07df6d",
 			"line_number": 305,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_reactive_test.gd",
 			"suite_name": "selector_reactive_test",
@@ -765,11 +681,9 @@
 			"attribute_index": -1,
 			"display_name": "test_always_executing_first_successful_node",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_always_executing_first_successful_node",
-			"guid": "59e6b2ec-2f6b41b-78c20cc-6e653693f4",
+			"guid": "d1423f4b-de534a4-7a11d2b-097dbadca9",
 			"line_number": 38,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -783,11 +697,9 @@
 			"attribute_index": -1,
 			"display_name": "test_execute_second_when_first_is_failing",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_execute_second_when_first_is_failing",
-			"guid": "ab1c24c1-63d7462-5a2c7c2-a64abb91a2",
+			"guid": "bffee9f1-cb994ff-2848026-dd31efec25",
 			"line_number": 45,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -801,11 +713,9 @@
 			"attribute_index": -1,
 			"display_name": "test_return_failure_of_none_is_succeeding",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_return_failure_of_none_is_succeeding",
-			"guid": "4313c622-784b4af-b9e4c86-15dfd6fdb2",
+			"guid": "f53c7e8e-113848d-cb13b5a-e7eaecdca8",
 			"line_number": 53,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -819,11 +729,9 @@
 			"attribute_index": -1,
 			"display_name": "test_not_interrupt_second_when_first_is_succeeding",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_not_interrupt_second_when_first_is_succeeding",
-			"guid": "365b54cb-3eec44c-8b58ce9-181a5f9a48",
+			"guid": "2db30506-38e74c3-98e048c-f19154dea2",
 			"line_number": 61,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -837,11 +745,9 @@
 			"attribute_index": -1,
 			"display_name": "test_not_interrupt_second_when_first_is_running",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_not_interrupt_second_when_first_is_running",
-			"guid": "20087d70-f416490-29428c7-ab071482f9",
+			"guid": "62e67c8f-71de449-b9675e2-c12bcc3872",
 			"line_number": 74,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -855,11 +761,9 @@
 			"attribute_index": -1,
 			"display_name": "test_tick_again_when_child_returns_running",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_tick_again_when_child_returns_running",
-			"guid": "5022afe4-21a4473-78d45a7-e1912ff7b4",
+			"guid": "17293a0b-d8a745c-5bc2011-863de8af1f",
 			"line_number": 87,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -873,11 +777,9 @@
 			"attribute_index": -1,
 			"display_name": "test_clear_running_child_after_run",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_clear_running_child_after_run",
-			"guid": "d9797b01-23814bd-da2e2b6-cdfd840366",
+			"guid": "c9ad2d5f-5f6a4d2-6b69494-c3cab35810",
 			"line_number": 96,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -891,11 +793,9 @@
 			"attribute_index": -1,
 			"display_name": "test_not_interrupt_first_after_finished",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_not_interrupt_first_after_finished",
-			"guid": "469fffb8-700e4f8-381e711-a7b2ce6ff0",
+			"guid": "0aecdb61-e52842a-59a245f-72eb519980",
 			"line_number": 106,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -909,11 +809,9 @@
 			"attribute_index": -1,
 			"display_name": "test_branch_change_resets_cooldown",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_branch_change_resets_cooldown",
-			"guid": "370b2c51-5e82473-2952a9c-44f7da504f",
+			"guid": "dd438632-abde41d-fac0f87-cc4bd11d46",
 			"line_number": 132,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -927,11 +825,9 @@
 			"attribute_index": -1,
 			"display_name": "test_nested_selector_interruption",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_nested_selector_interruption",
-			"guid": "f85b2e50-5fb64f0-39254b8-5525d52937",
+			"guid": "94ad22a1-585e464-dbf8791-76f6db84b6",
 			"line_number": 192,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -945,11 +841,9 @@
 			"attribute_index": -1,
 			"display_name": "test_complex_nested_selector_interruption",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_complex_nested_selector_interruption",
-			"guid": "7c5aa42b-df4a488-ca54f52-e4690eada4",
+			"guid": "f6ab471f-dd2d4c3-08dad13-d93751dee3",
 			"line_number": 229,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -963,11 +857,9 @@
 			"attribute_index": -1,
 			"display_name": "test_interrupt_all_children_after_all_failed",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_interrupt_all_children_after_all_failed",
-			"guid": "3c118fbf-e7264dd-6875b55-9bafad2b0b",
+			"guid": "b3156307-a91e4e4-4b833be-2c14b88ca6",
 			"line_number": 304,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -981,11 +873,9 @@
 			"attribute_index": -1,
 			"display_name": "test_nested_interrupt_after_all_failed",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_nested_interrupt_after_all_failed",
-			"guid": "17b957fd-a28747a-f9e957a-b1c80787c8",
+			"guid": "c0ad19f4-7d76479-4afe6db-e5e0e307a6",
 			"line_number": 364,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -999,11 +889,9 @@
 			"attribute_index": -1,
 			"display_name": "test_interrupt_all_children_after_failure_return",
 			"fully_qualified_name": "test.nodes.composites.selector_test.test_interrupt_all_children_after_failure_return",
-			"guid": "258c0156-e354419-490f580-7faf4e7ca0",
+			"guid": "c7517607-d6384e8-d903cbd-b630d3ced9",
 			"line_number": 428,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/selector_test.gd",
 			"suite_name": "selector_test",
@@ -1017,11 +905,9 @@
 			"attribute_index": -1,
 			"display_name": "test_always_executing_first_successful_node",
 			"fully_qualified_name": "test.nodes.composites.sequence_random_test.test_always_executing_first_successful_node",
-			"guid": "9b555c87-007b49e-1904d1f-791f677e27",
+			"guid": "f57fd9ea-34344c2-fb0ef5f-209acc021d",
 			"line_number": 39,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_random_test.gd",
 			"suite_name": "sequence_random_test",
@@ -1035,11 +921,9 @@
 			"attribute_index": -1,
 			"display_name": "test_execute_second_when_first_is_failing",
 			"fully_qualified_name": "test.nodes.composites.sequence_random_test.test_execute_second_when_first_is_failing",
-			"guid": "affdd22a-d23f4dd-7b0d428-b08cfb2dfb",
+			"guid": "91461eb9-6ac74af-a8c488c-5c8994007d",
 			"line_number": 49,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_random_test.gd",
 			"suite_name": "sequence_random_test",
@@ -1053,11 +937,9 @@
 			"attribute_index": -1,
 			"display_name": "test_random_even_execution",
 			"fully_qualified_name": "test.nodes.composites.sequence_random_test.test_random_even_execution",
-			"guid": "758201af-383a4aa-a8a1e02-869ae30fa5",
+			"guid": "e109d0f8-676d462-5999949-c009bcb3d3",
 			"line_number": 60,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_random_test.gd",
 			"suite_name": "sequence_random_test",
@@ -1071,11 +953,9 @@
 			"attribute_index": -1,
 			"display_name": "test_weighted_random_sampling",
 			"fully_qualified_name": "test.nodes.composites.sequence_random_test.test_weighted_random_sampling",
-			"guid": "159086cc-20664fb-3b7f09f-32ae6d0940",
+			"guid": "c8836aaa-d2d64b2-cb1bd3e-8293b504bf",
 			"line_number": 68,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_random_test.gd",
 			"suite_name": "sequence_random_test",
@@ -1089,11 +969,9 @@
 			"attribute_index": -1,
 			"display_name": "test_return_failure_of_none_is_succeeding",
 			"fully_qualified_name": "test.nodes.composites.sequence_random_test.test_return_failure_of_none_is_succeeding",
-			"guid": "2ce4179d-a45b459-b94e161-0ea859e060",
+			"guid": "741531c1-2cff423-6b79bcd-683f762f41",
 			"line_number": 98,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_random_test.gd",
 			"suite_name": "sequence_random_test",
@@ -1107,11 +985,9 @@
 			"attribute_index": -1,
 			"display_name": "test_clear_running_child_after_run",
 			"fully_qualified_name": "test.nodes.composites.sequence_random_test.test_clear_running_child_after_run",
-			"guid": "2ff3062e-cb6f43d-6815673-c86daac535",
+			"guid": "ac78b416-73d443c-88799c5-7f0db76ce0",
 			"line_number": 108,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_random_test.gd",
 			"suite_name": "sequence_random_test",
@@ -1125,11 +1001,9 @@
 			"attribute_index": -1,
 			"display_name": "test_always_exexuting_all_successful_nodes",
 			"fully_qualified_name": "test.nodes.composites.sequence_reactive_test.test_always_exexuting_all_successful_nodes",
-			"guid": "10ba3e49-23804a2-cae7044-d578f8e0d5",
+			"guid": "10a8ca28-03344d1-4a3da41-ade2b10cd7",
 			"line_number": 37,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_reactive_test.gd",
 			"suite_name": "sequence_reactive_test",
@@ -1143,11 +1017,9 @@
 			"attribute_index": -1,
 			"display_name": "test_never_execute_second_when_first_is_failing",
 			"fully_qualified_name": "test.nodes.composites.sequence_reactive_test.test_never_execute_second_when_first_is_failing",
-			"guid": "b5c040b0-6e114a4-ba97be4-b0d7e51012",
+			"guid": "37c91867-602a46b-c8e3876-00e024848f",
 			"line_number": 47,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_reactive_test.gd",
 			"suite_name": "sequence_reactive_test",
@@ -1161,11 +1033,9 @@
 			"attribute_index": -1,
 			"display_name": "test_keeps_running_child_until_success",
 			"fully_qualified_name": "test.nodes.composites.sequence_reactive_test.test_keeps_running_child_until_success",
-			"guid": "1dd8bad5-75524b1-7ad1262-f47e63effb",
+			"guid": "7308af39-fbca400-0aee18c-b6b18e231c",
 			"line_number": 58,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_reactive_test.gd",
 			"suite_name": "sequence_reactive_test",
@@ -1179,11 +1049,9 @@
 			"attribute_index": -1,
 			"display_name": "test_keeps_running_child_until_failure",
 			"fully_qualified_name": "test.nodes.composites.sequence_reactive_test.test_keeps_running_child_until_failure",
-			"guid": "0978b53c-15d04dd-29bb7c9-4f77f0b03a",
+			"guid": "1c45eeeb-c357421-ba61eaa-32f6c0cf2d",
 			"line_number": 79,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_reactive_test.gd",
 			"suite_name": "sequence_reactive_test",
@@ -1197,11 +1065,9 @@
 			"attribute_index": -1,
 			"display_name": "test_restart_when_child_returns_failure",
 			"fully_qualified_name": "test.nodes.composites.sequence_reactive_test.test_restart_when_child_returns_failure",
-			"guid": "5c66bc14-343047c-f94584e-df4ea0a28e",
+			"guid": "c0b9b17b-97ac4ee-c9c491a-aea06a12f3",
 			"line_number": 100,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_reactive_test.gd",
 			"suite_name": "sequence_reactive_test",
@@ -1215,11 +1081,9 @@
 			"attribute_index": -1,
 			"display_name": "test_restart_again_when_child_returns_running",
 			"fully_qualified_name": "test.nodes.composites.sequence_reactive_test.test_restart_again_when_child_returns_running",
-			"guid": "d6f97cda-a62d48d-197efcf-363418c925",
+			"guid": "b34d1866-175b4c4-79bfa7c-6d4ecb2b5f",
 			"line_number": 109,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_reactive_test.gd",
 			"suite_name": "sequence_reactive_test",
@@ -1233,11 +1097,9 @@
 			"attribute_index": -1,
 			"display_name": "test_interrupt_second_when_first_is_running",
 			"fully_qualified_name": "test.nodes.composites.sequence_reactive_test.test_interrupt_second_when_first_is_running",
-			"guid": "db407946-934248b-bab9773-94203ee923",
+			"guid": "2cfcc35a-7ac546a-bb491dd-04a003b891",
 			"line_number": 118,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_reactive_test.gd",
 			"suite_name": "sequence_reactive_test",
@@ -1251,11 +1113,9 @@
 			"attribute_index": -1,
 			"display_name": "test_clear_running_child_after_run",
 			"fully_qualified_name": "test.nodes.composites.sequence_reactive_test.test_clear_running_child_after_run",
-			"guid": "528479e1-76bb406-28dd018-ff951b9cdf",
+			"guid": "20096387-8515491-1aeb069-7fab3500d8",
 			"line_number": 131,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_reactive_test.gd",
 			"suite_name": "sequence_reactive_test",
@@ -1269,11 +1129,9 @@
 			"attribute_index": -1,
 			"display_name": "test_branch_change_detection_on_failure",
 			"fully_qualified_name": "test.nodes.composites.sequence_reactive_test.test_branch_change_detection_on_failure",
-			"guid": "4fc72b70-f857417-abf1532-464935bd02",
+			"guid": "385bc2b0-040a4fe-6891b54-6c1d2377e8",
 			"line_number": 141,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_reactive_test.gd",
 			"suite_name": "sequence_reactive_test",
@@ -1287,11 +1145,9 @@
 			"attribute_index": -1,
 			"display_name": "test_nested_sequence_interrupt",
 			"fully_qualified_name": "test.nodes.composites.sequence_reactive_test.test_nested_sequence_interrupt",
-			"guid": "7419f94d-e16d465-093105b-ce60ce4794",
+			"guid": "fcff4689-a686422-fb90d39-5534127a3e",
 			"line_number": 173,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_reactive_test.gd",
 			"suite_name": "sequence_reactive_test",
@@ -1305,11 +1161,9 @@
 			"attribute_index": -1,
 			"display_name": "test_nested_sequence_child_failure_interrupt",
 			"fully_qualified_name": "test.nodes.composites.sequence_reactive_test.test_nested_sequence_child_failure_interrupt",
-			"guid": "c3fa0285-cdb24df-7bd13f7-e9b39f6da6",
+			"guid": "6d00b36f-b3fd449-4b6d64a-8e09838004",
 			"line_number": 232,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_reactive_test.gd",
 			"suite_name": "sequence_reactive_test",
@@ -1323,11 +1177,9 @@
 			"attribute_index": -1,
 			"display_name": "test_always_exexuting_all_successful_nodes",
 			"fully_qualified_name": "test.nodes.composites.sequence_star_test.test_always_exexuting_all_successful_nodes",
-			"guid": "463051e2-3ad642c-4bf6a8a-677ccbff29",
+			"guid": "77811464-f50847e-fa8cdec-8773add522",
 			"line_number": 38,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_star_test.gd",
 			"suite_name": "sequence_star_test",
@@ -1341,11 +1193,9 @@
 			"attribute_index": -1,
 			"display_name": "test_never_execute_second_when_first_is_failing",
 			"fully_qualified_name": "test.nodes.composites.sequence_star_test.test_never_execute_second_when_first_is_failing",
-			"guid": "d1be96f9-6b7a4e6-18c6bab-730b952e4c",
+			"guid": "2b12deb0-9ce0482-88935f7-953817d0a2",
 			"line_number": 48,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_star_test.gd",
 			"suite_name": "sequence_star_test",
@@ -1359,11 +1209,9 @@
 			"attribute_index": -1,
 			"display_name": "test_keeps_running_child_until_success",
 			"fully_qualified_name": "test.nodes.composites.sequence_star_test.test_keeps_running_child_until_success",
-			"guid": "a0832069-57be4be-fa8b039-e294f9a43c",
+			"guid": "59c25d6c-4a984dd-ba1e28f-24323c41b4",
 			"line_number": 59,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_star_test.gd",
 			"suite_name": "sequence_star_test",
@@ -1377,11 +1225,9 @@
 			"attribute_index": -1,
 			"display_name": "test_keeps_running_child_until_failure",
 			"fully_qualified_name": "test.nodes.composites.sequence_star_test.test_keeps_running_child_until_failure",
-			"guid": "6ddfacbf-71eb43f-b881d62-3991944bbf",
+			"guid": "13f6157d-8bc24ad-88856c1-d61eb2bc4f",
 			"line_number": 80,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_star_test.gd",
 			"suite_name": "sequence_star_test",
@@ -1395,11 +1241,9 @@
 			"attribute_index": -1,
 			"display_name": "test_tick_again_when_child_returns_failure",
 			"fully_qualified_name": "test.nodes.composites.sequence_star_test.test_tick_again_when_child_returns_failure",
-			"guid": "f56e890e-85a44fd-4b16713-bc4bfbcb8b",
+			"guid": "7847179e-26f64a8-9be8315-5143c52df0",
 			"line_number": 103,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_star_test.gd",
 			"suite_name": "sequence_star_test",
@@ -1413,11 +1257,9 @@
 			"attribute_index": -1,
 			"display_name": "test_tick_again_when_child_returns_running",
 			"fully_qualified_name": "test.nodes.composites.sequence_star_test.test_tick_again_when_child_returns_running",
-			"guid": "11c48a08-5124445-3a00679-f6dfc5944a",
+			"guid": "19b3ddbe-5c044d6-e8af62b-62f3af24de",
 			"line_number": 112,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_star_test.gd",
 			"suite_name": "sequence_star_test",
@@ -1431,11 +1273,9 @@
 			"attribute_index": -1,
 			"display_name": "test_clear_running_child_after_run",
 			"fully_qualified_name": "test.nodes.composites.sequence_star_test.test_clear_running_child_after_run",
-			"guid": "46bce228-5b2442b-f840c0d-c8b7d9302a",
+			"guid": "f151045f-7007431-989674f-20c14223fd",
 			"line_number": 121,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_star_test.gd",
 			"suite_name": "sequence_star_test",
@@ -1449,11 +1289,9 @@
 			"attribute_index": -1,
 			"display_name": "test_branch_change_detection_on_failure",
 			"fully_qualified_name": "test.nodes.composites.sequence_star_test.test_branch_change_detection_on_failure",
-			"guid": "fce9f6e3-1362442-fa1cd1f-56557cca8a",
+			"guid": "b7d7eda5-b30c495-69d27c6-c21f9cd2c1",
 			"line_number": 131,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_star_test.gd",
 			"suite_name": "sequence_star_test",
@@ -1467,11 +1305,9 @@
 			"attribute_index": -1,
 			"display_name": "test_branch_change_detection_on_consequent_failure",
 			"fully_qualified_name": "test.nodes.composites.sequence_star_test.test_branch_change_detection_on_consequent_failure",
-			"guid": "fe0a45fb-ffd248a-ca3d6b2-77cef8ea4f",
+			"guid": "e7294860-b0cc4f6-b8e7353-aabb64150f",
 			"line_number": 157,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_star_test.gd",
 			"suite_name": "sequence_star_test",
@@ -1485,11 +1321,9 @@
 			"attribute_index": -1,
 			"display_name": "test_nested_sequence_interrupt",
 			"fully_qualified_name": "test.nodes.composites.sequence_star_test.test_nested_sequence_interrupt",
-			"guid": "cd09e962-eb2b4e0-0bd7c03-63f2a9270f",
+			"guid": "a5407160-e79440e-ea61ae2-91de01dbfb",
 			"line_number": 188,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_star_test.gd",
 			"suite_name": "sequence_star_test",
@@ -1503,11 +1337,9 @@
 			"attribute_index": -1,
 			"display_name": "test_nested_sequence_child_failure_interrupt",
 			"fully_qualified_name": "test.nodes.composites.sequence_star_test.test_nested_sequence_child_failure_interrupt",
-			"guid": "5ea6f8c8-31574c1-88e59c2-e73501339f",
+			"guid": "98298060-21a24a3-f876695-c7de5da2c3",
 			"line_number": 247,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_star_test.gd",
 			"suite_name": "sequence_star_test",
@@ -1521,11 +1353,9 @@
 			"attribute_index": -1,
 			"display_name": "test_always_executing_all_successful_nodes",
 			"fully_qualified_name": "test.nodes.composites.sequence_test.test_always_executing_all_successful_nodes",
-			"guid": "705806f7-12d140f-2845131-50600144a6",
+			"guid": "485bd8ca-c87b42a-db51dd9-c891e67b07",
 			"line_number": 37,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_test.gd",
 			"suite_name": "sequence_test",
@@ -1539,11 +1369,9 @@
 			"attribute_index": -1,
 			"display_name": "test_never_execute_second_when_first_is_failing",
 			"fully_qualified_name": "test.nodes.composites.sequence_test.test_never_execute_second_when_first_is_failing",
-			"guid": "fe7d0209-2a2d463-486b23d-522ca8e5a5",
+			"guid": "5efbd77a-414c446-a97d882-5c8c363dc5",
 			"line_number": 44,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_test.gd",
 			"suite_name": "sequence_test",
@@ -1557,11 +1385,9 @@
 			"attribute_index": -1,
 			"display_name": "test_not_interrupt_second_when_first_is_failing",
 			"fully_qualified_name": "test.nodes.composites.sequence_test.test_not_interrupt_second_when_first_is_failing",
-			"guid": "de5eb6da-4f4743a-8a999ab-9ae4651f33",
+			"guid": "4191c7e3-fbc342c-3bf2c5a-b61da326b7",
 			"line_number": 52,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_test.gd",
 			"suite_name": "sequence_test",
@@ -1575,11 +1401,9 @@
 			"attribute_index": -1,
 			"display_name": "test_not_interrupting_second_when_first_is_running",
 			"fully_qualified_name": "test.nodes.composites.sequence_test.test_not_interrupting_second_when_first_is_running",
-			"guid": "a7f7ea42-0e83452-b8fd499-1388f63dce",
+			"guid": "91182bc7-6e2c4b5-39e0482-7d950164ef",
 			"line_number": 65,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_test.gd",
 			"suite_name": "sequence_test",
@@ -1593,11 +1417,9 @@
 			"attribute_index": -1,
 			"display_name": "test_restart_when_child_returns_failure",
 			"fully_qualified_name": "test.nodes.composites.sequence_test.test_restart_when_child_returns_failure",
-			"guid": "01a61e06-baca4a3-3b8c5ba-67d57c6fe5",
+			"guid": "63ecea57-56404ad-9a683c1-4efbead1f8",
 			"line_number": 78,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_test.gd",
 			"suite_name": "sequence_test",
@@ -1611,11 +1433,9 @@
 			"attribute_index": -1,
 			"display_name": "test_tick_again_when_child_returns_running",
 			"fully_qualified_name": "test.nodes.composites.sequence_test.test_tick_again_when_child_returns_running",
-			"guid": "25468f02-f234486-eabf48b-50ed69f45c",
+			"guid": "8a54bb11-4a5e48e-184eb89-6d60d9e987",
 			"line_number": 87,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_test.gd",
 			"suite_name": "sequence_test",
@@ -1629,11 +1449,9 @@
 			"attribute_index": -1,
 			"display_name": "test_clear_running_child_after_run",
 			"fully_qualified_name": "test.nodes.composites.sequence_test.test_clear_running_child_after_run",
-			"guid": "627e411d-fc82408-88fac97-400cf5e93c",
+			"guid": "9d1fdfad-77434d1-59b293e-54dc39af6d",
 			"line_number": 96,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_test.gd",
 			"suite_name": "sequence_test",
@@ -1647,11 +1465,9 @@
 			"attribute_index": -1,
 			"display_name": "test_not_interrupt_first_after_finished",
 			"fully_qualified_name": "test.nodes.composites.sequence_test.test_not_interrupt_first_after_finished",
-			"guid": "ea2916cf-74bf40a-f816427-dce83e6fa8",
+			"guid": "ca35249b-ffd9477-88722ff-b055bd544d",
 			"line_number": 106,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_test.gd",
 			"suite_name": "sequence_test",
@@ -1665,11 +1481,9 @@
 			"attribute_index": -1,
 			"display_name": "test_branch_change_detection_on_consequent_failure",
 			"fully_qualified_name": "test.nodes.composites.sequence_test.test_branch_change_detection_on_consequent_failure",
-			"guid": "9a663e40-adc0485-7811c00-ecd573ca03",
+			"guid": "adc6a7c0-64164f7-6b7f441-2084f91191",
 			"line_number": 130,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_test.gd",
 			"suite_name": "sequence_test",
@@ -1683,11 +1497,9 @@
 			"attribute_index": -1,
 			"display_name": "test_nested_sequence_interrupt",
 			"fully_qualified_name": "test.nodes.composites.sequence_test.test_nested_sequence_interrupt",
-			"guid": "ebc26ab9-ebee4f9-dbd92c9-d6ba82a26a",
+			"guid": "5deb079d-d48147d-d8960bf-7cecaae525",
 			"line_number": 160,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_test.gd",
 			"suite_name": "sequence_test",
@@ -1701,11 +1513,9 @@
 			"attribute_index": -1,
 			"display_name": "test_nested_sequence_child_failure_interrupt",
 			"fully_qualified_name": "test.nodes.composites.sequence_test.test_nested_sequence_child_failure_interrupt",
-			"guid": "6261f43d-f3e4401-3b115a1-fdf4390364",
+			"guid": "f9387fd6-2b3b4fb-388278a-92abd36692",
 			"line_number": 216,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/sequence_test.gd",
 			"suite_name": "sequence_test",
@@ -1719,11 +1529,9 @@
 			"attribute_index": -1,
 			"display_name": "test_always_return_first_node_result",
 			"fully_qualified_name": "test.nodes.composites.simple_parallel_test.test_always_return_first_node_result",
-			"guid": "562b931f-10dd4e7-99ab15d-f080ae558f",
+			"guid": "a41af393-e6b1493-78d7fc8-f1c539b666",
 			"line_number": 37,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/simple_parallel_test.gd",
 			"suite_name": "simple_parallel_test",
@@ -1737,11 +1545,9 @@
 			"attribute_index": -1,
 			"display_name": "test_interrupt_second_when_first_is_succeeding",
 			"fully_qualified_name": "test.nodes.composites.simple_parallel_test.test_interrupt_second_when_first_is_succeeding",
-			"guid": "4583c5c9-c55c48d-5b322e6-4ef22e5757",
+			"guid": "3b55e1a3-49a5491-19eb71b-4c42df9b4f",
 			"line_number": 50,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/simple_parallel_test.gd",
 			"suite_name": "simple_parallel_test",
@@ -1755,11 +1561,9 @@
 			"attribute_index": -1,
 			"display_name": "test_interrupt_second_when_first_is_failing",
 			"fully_qualified_name": "test.nodes.composites.simple_parallel_test.test_interrupt_second_when_first_is_failing",
-			"guid": "55aed4ab-78ec498-9899833-4b43aa33ef",
+			"guid": "a2d09fbc-f3ad44b-99494ca-8f8007ed9a",
 			"line_number": 63,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/simple_parallel_test.gd",
 			"suite_name": "simple_parallel_test",
@@ -1773,11 +1577,9 @@
 			"attribute_index": -1,
 			"display_name": "test_continue_tick_when_child_returns_failing",
 			"fully_qualified_name": "test.nodes.composites.simple_parallel_test.test_continue_tick_when_child_returns_failing",
-			"guid": "872fe309-692c4a4-ab5f2b4-222b932c83",
+			"guid": "00104b66-40564b8-d8b93a8-092bc5d64e",
 			"line_number": 76,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/simple_parallel_test.gd",
 			"suite_name": "simple_parallel_test",
@@ -1791,11 +1593,9 @@
 			"attribute_index": -1,
 			"display_name": "test_child_continue_tick_in_delay_mode",
 			"fully_qualified_name": "test.nodes.composites.simple_parallel_test.test_child_continue_tick_in_delay_mode",
-			"guid": "8d586b4d-e86b49d-98b5209-9ccee7ad69",
+			"guid": "2cd06d90-c28d4b2-f9beb0e-8e8b9ecff6",
 			"line_number": 88,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/simple_parallel_test.gd",
 			"suite_name": "simple_parallel_test",
@@ -1809,11 +1609,9 @@
 			"attribute_index": -1,
 			"display_name": "test_child_tick_count",
 			"fully_qualified_name": "test.nodes.composites.simple_parallel_test.test_child_tick_count",
-			"guid": "5c4b7b03-366c400-995dc2c-f15f2caa50",
+			"guid": "2affac84-726a4ab-898d04c-e8e45c1ef4",
 			"line_number": 107,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/simple_parallel_test.gd",
 			"suite_name": "simple_parallel_test",
@@ -1827,11 +1625,9 @@
 			"attribute_index": -1,
 			"display_name": "test_nested_simple_parallel",
 			"fully_qualified_name": "test.nodes.composites.simple_parallel_test.test_nested_simple_parallel",
-			"guid": "be020761-ef2543e-9b5ed3b-437ab35ba0",
+			"guid": "f46156a4-e703423-fae1607-826c576d49",
 			"line_number": 133,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/composites/simple_parallel_test.gd",
 			"suite_name": "simple_parallel_test",
@@ -1845,11 +1641,9 @@
 			"attribute_index": -1,
 			"display_name": "test_running_then_fail",
 			"fully_qualified_name": "test.nodes.decorators.cooldown_test.test_running_then_fail",
-			"guid": "8dcd6d1b-5ae84c6-2aaea85-148eca69c6",
+			"guid": "6319680a-f7ee4ff-2866b16-c7490f9d47",
 			"line_number": 49,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/cooldown_test.gd",
 			"suite_name": "cooldown_test",
@@ -1863,11 +1657,9 @@
 			"attribute_index": -1,
 			"display_name": "test_interrupt_propagates_when_actionleaf",
 			"fully_qualified_name": "test.nodes.decorators.cooldown_test.test_interrupt_propagates_when_actionleaf",
-			"guid": "a614c713-3e69480-ca69926-9132d94cf2",
+			"guid": "ebbb21e6-b8a5458-69383b7-9d82345ef1",
 			"line_number": 61,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/cooldown_test.gd",
 			"suite_name": "cooldown_test",
@@ -1881,11 +1673,9 @@
 			"attribute_index": -1,
 			"display_name": "test_interrupt_propagates_when_composite",
 			"fully_qualified_name": "test.nodes.decorators.cooldown_test.test_interrupt_propagates_when_composite",
-			"guid": "305b4fd3-88c9416-cac6ac9-0a2fb4a353",
+			"guid": "58432a9b-f30f4ce-6969891-1e69be1148",
 			"line_number": 71,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/cooldown_test.gd",
 			"suite_name": "cooldown_test",
@@ -1899,11 +1689,9 @@
 			"attribute_index": -1,
 			"display_name": "test_after_run_called_on_success",
 			"fully_qualified_name": "test.nodes.decorators.cooldown_test.test_after_run_called_on_success",
-			"guid": "edb39990-96d2475-cae4ed2-fe1d917f14",
+			"guid": "3153d185-c4d743c-59baf4e-1d07626835",
 			"line_number": 88,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/cooldown_test.gd",
 			"suite_name": "cooldown_test",
@@ -1917,11 +1705,9 @@
 			"attribute_index": -1,
 			"display_name": "test_after_run_called_on_failure",
 			"fully_qualified_name": "test.nodes.decorators.cooldown_test.test_after_run_called_on_failure",
-			"guid": "33330437-4f024e0-f818589-e087463704",
+			"guid": "6dc618f8-1dc44da-69cef23-db9561fe0f",
 			"line_number": 103,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/cooldown_test.gd",
 			"suite_name": "cooldown_test",
@@ -1935,11 +1721,9 @@
 			"attribute_index": -1,
 			"display_name": "test_after_run_not_called_during_cooldown",
 			"fully_qualified_name": "test.nodes.decorators.cooldown_test.test_after_run_not_called_during_cooldown",
-			"guid": "90efd309-eaac461-aba5572-cfc9c13b58",
+			"guid": "8aa70957-a08840c-6a35537-02d1f94c93",
 			"line_number": 118,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/cooldown_test.gd",
 			"suite_name": "cooldown_test",
@@ -1953,11 +1737,9 @@
 			"attribute_index": -1,
 			"display_name": "test_before_run_only_called_once_per_cooldown",
 			"fully_qualified_name": "test.nodes.decorators.cooldown_test.test_before_run_only_called_once_per_cooldown",
-			"guid": "3a1f488f-b5eb493-4b69d15-c3d620046f",
+			"guid": "c2fd8696-6cec4de-b8df9c7-d2acb96b28",
 			"line_number": 134,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/cooldown_test.gd",
 			"suite_name": "cooldown_test",
@@ -1971,11 +1753,9 @@
 			"attribute_index": -1,
 			"display_name": "test_cooldown_reset_on_interrupt",
 			"fully_qualified_name": "test.nodes.decorators.cooldown_test.test_cooldown_reset_on_interrupt",
-			"guid": "d6f7572c-888b480-a9d0e39-707ddfdbd0",
+			"guid": "f6c0fcc8-d66d459-9b2f4ee-a1a70ba6bb",
 			"line_number": 153,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/cooldown_test.gd",
 			"suite_name": "cooldown_test",
@@ -1989,11 +1769,9 @@
 			"attribute_index": -1,
 			"display_name": "test_return_success_after_delay",
 			"fully_qualified_name": "test.nodes.decorators.delayer_test.test_return_success_after_delay",
-			"guid": "4396459b-dcb64ac-f8a62c5-8383aae3b7",
+			"guid": "11481477-5b4946f-8bf5138-375925045e",
 			"line_number": 35,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/delayer_test.gd",
 			"suite_name": "delayer_test",
@@ -2007,11 +1785,9 @@
 			"attribute_index": -1,
 			"display_name": "test_return_running_after_delay",
 			"fully_qualified_name": "test.nodes.decorators.delayer_test.test_return_running_after_delay",
-			"guid": "b91c7ccc-373842e-faf29b3-174e50ea93",
+			"guid": "995add94-421f485-98973f9-526fac44e6",
 			"line_number": 45,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/delayer_test.gd",
 			"suite_name": "delayer_test",
@@ -2025,11 +1801,9 @@
 			"attribute_index": -1,
 			"display_name": "test_after_run_called_on_success",
 			"fully_qualified_name": "test.nodes.decorators.delayer_test.test_after_run_called_on_success",
-			"guid": "981cce79-d05449e-987e075-de6ff3221b",
+			"guid": "4efddd48-2f95419-9acd8de-9c46938ee1",
 			"line_number": 61,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/delayer_test.gd",
 			"suite_name": "delayer_test",
@@ -2043,11 +1817,9 @@
 			"attribute_index": -1,
 			"display_name": "test_after_run_called_on_failure",
 			"fully_qualified_name": "test.nodes.decorators.delayer_test.test_after_run_called_on_failure",
-			"guid": "abff27ca-aeb5436-8bfe631-ff8c874989",
+			"guid": "4168880f-deb0457-1ad4698-7c626e6772",
 			"line_number": 73,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/delayer_test.gd",
 			"suite_name": "delayer_test",
@@ -2061,11 +1833,9 @@
 			"attribute_index": -1,
 			"display_name": "test_after_run_not_called_during_delay",
 			"fully_qualified_name": "test.nodes.decorators.delayer_test.test_after_run_not_called_during_delay",
-			"guid": "6c86b63c-6aa04c8-79244bc-2f36ae7daf",
+			"guid": "00d10c99-66634a6-7996901-9e314df8f2",
 			"line_number": 85,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/delayer_test.gd",
 			"suite_name": "delayer_test",
@@ -2079,11 +1849,9 @@
 			"attribute_index": -1,
 			"display_name": "test_before_run_only_called_once_per_run",
 			"fully_qualified_name": "test.nodes.decorators.delayer_test.test_before_run_only_called_once_per_run",
-			"guid": "3add26ee-487b494-6af9c3c-bb48e1d326",
+			"guid": "7abbe2ce-1f004fa-2bab230-5fc087f760",
 			"line_number": 98,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/delayer_test.gd",
 			"suite_name": "delayer_test",
@@ -2097,11 +1865,9 @@
 			"attribute_index": -1,
 			"display_name": "test_delay_reset_on_interrupt",
 			"fully_qualified_name": "test.nodes.decorators.delayer_test.test_delay_reset_on_interrupt",
-			"guid": "ebf0266b-a5ef4aa-8a6daa6-8da29522f4",
+			"guid": "6af9855e-31d14ad-18f2f00-368fba2e19",
 			"line_number": 122,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/delayer_test.gd",
 			"suite_name": "delayer_test",
@@ -2115,11 +1881,9 @@
 			"attribute_index": -1,
 			"display_name": "test_tick",
 			"fully_qualified_name": "test.nodes.decorators.failer_test.test_tick",
-			"guid": "5b08b6ee-9c4f437-cb9e3f8-320169555d",
+			"guid": "ba443fba-e8564cf-4b2f903-182a5c2010",
 			"line_number": 33,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/failer_test.gd",
 			"suite_name": "failer_test",
@@ -2133,11 +1897,9 @@
 			"attribute_index": -1,
 			"display_name": "test_clear_running_child_after_run",
 			"fully_qualified_name": "test.nodes.decorators.failer_test.test_clear_running_child_after_run",
-			"guid": "b2d4cf3f-87ff48e-d848662-bdb9f9d73f",
+			"guid": "89742a24-7c2542e-0b6e580-da9541b8cf",
 			"line_number": 38,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/failer_test.gd",
 			"suite_name": "failer_test",
@@ -2151,11 +1913,9 @@
 			"attribute_index": -1,
 			"display_name": "test_invert_success_to_failure",
 			"fully_qualified_name": "test.nodes.decorators.inverter_test.test_invert_success_to_failure",
-			"guid": "1529df40-f7e442d-7a82ac4-6a642748cb",
+			"guid": "1f3b4d71-39d1425-1aa0900-b485a5c3cd",
 			"line_number": 33,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/inverter_test.gd",
 			"suite_name": "inverter_test",
@@ -2169,11 +1929,9 @@
 			"attribute_index": -1,
 			"display_name": "test_invert_failure_to_success",
 			"fully_qualified_name": "test.nodes.decorators.inverter_test.test_invert_failure_to_success",
-			"guid": "92aa21e8-d61543f-09bfde5-d469b28af4",
+			"guid": "9107c629-8a3b4fc-ab333da-c8457e8781",
 			"line_number": 38,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/inverter_test.gd",
 			"suite_name": "inverter_test",
@@ -2187,11 +1945,9 @@
 			"attribute_index": -1,
 			"display_name": "test_clear_running_child_after_run",
 			"fully_qualified_name": "test.nodes.decorators.inverter_test.test_clear_running_child_after_run",
-			"guid": "4c070c37-b49c447-ead2d85-d1394c1af8",
+			"guid": "8261725c-5b914f0-9872089-efbd7558c1",
 			"line_number": 43,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/inverter_test.gd",
 			"suite_name": "inverter_test",
@@ -2205,11 +1961,9 @@
 			"attribute_index": 0,
 			"display_name": "test_max_count:0 (2)",
 			"fully_qualified_name": "test.nodes.decorators.limiter_test.test_max_count.test_max_count:0 (2)",
-			"guid": "25f7651c-413b4d0-e8732aa-85d6c86568",
+			"guid": "7418e035-6e19446-fb73ae1-9751f5bc9c",
 			"line_number": 33,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/limiter_test.gd",
 			"suite_name": "limiter_test",
@@ -2223,11 +1977,9 @@
 			"attribute_index": 1,
 			"display_name": "test_max_count:1 (0)",
 			"fully_qualified_name": "test.nodes.decorators.limiter_test.test_max_count.test_max_count:1 (0)",
-			"guid": "435ec398-10c940c-9b84e42-3a185449d4",
+			"guid": "ae9d6d28-33ee46e-b9fec9f-0851737dd4",
 			"line_number": 33,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/limiter_test.gd",
 			"suite_name": "limiter_test",
@@ -2241,11 +1993,9 @@
 			"attribute_index": -1,
 			"display_name": "test_interrupt_after_run",
 			"fully_qualified_name": "test.nodes.decorators.limiter_test.test_interrupt_after_run",
-			"guid": "bf002e3c-1f1f4c1-f83a142-ee3e19921f",
+			"guid": "98905729-8715484-f8ce605-ff30c0fa4f",
 			"line_number": 45,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/limiter_test.gd",
 			"suite_name": "limiter_test",
@@ -2259,11 +2009,9 @@
 			"attribute_index": -1,
 			"display_name": "test_clear_running_child_after_run",
 			"fully_qualified_name": "test.nodes.decorators.limiter_test.test_clear_running_child_after_run",
-			"guid": "f2019812-c8f9461-9bf6211-1d8a066d21",
+			"guid": "f6c6ea5b-117c4c2-88b1960-1271129b8f",
 			"line_number": 56,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/limiter_test.gd",
 			"suite_name": "limiter_test",
@@ -2277,11 +2025,9 @@
 			"attribute_index": -1,
 			"display_name": "test_counter_reset_on_interrupt",
 			"fully_qualified_name": "test.nodes.decorators.limiter_test.test_counter_reset_on_interrupt",
-			"guid": "c0012a31-a67b43e-7a8b02e-2445a27f1f",
+			"guid": "be103143-35a04c4-38a09f2-bcc103cb28",
 			"line_number": 66,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/limiter_test.gd",
 			"suite_name": "limiter_test",
@@ -2295,11 +2041,9 @@
 			"attribute_index": 0,
 			"display_name": "test_repetitions:0 (2)",
 			"fully_qualified_name": "test.nodes.decorators.repeater_test.test_repetitions.test_repetitions:0 (2)",
-			"guid": "5d29ed00-bad54b7-0a7c179-2e8e1c872c",
+			"guid": "ab2d7648-e31d4a9-9b61f6d-0ab23069f9",
 			"line_number": 44,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/repeater_test.gd",
 			"suite_name": "repeater_test",
@@ -2313,11 +2057,9 @@
 			"attribute_index": 1,
 			"display_name": "test_repetitions:1 (0)",
 			"fully_qualified_name": "test.nodes.decorators.repeater_test.test_repetitions.test_repetitions:1 (0)",
-			"guid": "e559bc8e-552a467-aacdd58-bffa8f6e4a",
+			"guid": "253b40ee-43da4d9-da2271c-80c242b678",
 			"line_number": 44,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/repeater_test.gd",
 			"suite_name": "repeater_test",
@@ -2331,11 +2073,9 @@
 			"attribute_index": -1,
 			"display_name": "test_failure",
 			"fully_qualified_name": "test.nodes.decorators.repeater_test.test_failure",
-			"guid": "5c94399f-87bb413-fa1a442-f23bbc2542",
+			"guid": "9eff9840-3c5c40b-1908a94-ecaa80b0e2",
 			"line_number": 63,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/repeater_test.gd",
 			"suite_name": "repeater_test",
@@ -2349,11 +2089,9 @@
 			"attribute_index": -1,
 			"display_name": "test_counter_reset_on_interrupt",
 			"fully_qualified_name": "test.nodes.decorators.repeater_test.test_counter_reset_on_interrupt",
-			"guid": "5eb84548-b31f4bf-4bacbb1-1df686df38",
+			"guid": "bbfdfe1b-9b8b4ae-68e05e1-b57ca09fc3",
 			"line_number": 99,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/repeater_test.gd",
 			"suite_name": "repeater_test",
@@ -2367,11 +2105,9 @@
 			"attribute_index": -1,
 			"display_name": "test_tick",
 			"fully_qualified_name": "test.nodes.decorators.succeeder_test.test_tick",
-			"guid": "c7975e01-26144a0-ca4d21d-355c0b5f23",
+			"guid": "e3bd0768-bafd4df-a8d4b44-e9faf98074",
 			"line_number": 33,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/succeeder_test.gd",
 			"suite_name": "succeeder_test",
@@ -2385,11 +2121,9 @@
 			"attribute_index": -1,
 			"display_name": "test_clear_running_child_after_run",
 			"fully_qualified_name": "test.nodes.decorators.succeeder_test.test_clear_running_child_after_run",
-			"guid": "6a9dfcf6-5393480-b9b06b3-254ff48670",
+			"guid": "c7732cc9-cfa24a9-ab8e95d-e33a784917",
 			"line_number": 38,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/succeeder_test.gd",
 			"suite_name": "succeeder_test",
@@ -2403,11 +2137,9 @@
 			"attribute_index": -1,
 			"display_name": "test_return_failure_when_child_exceeds_time_limiter",
 			"fully_qualified_name": "test.nodes.decorators.time_limiter_test.test_return_failure_when_child_exceeds_time_limiter",
-			"guid": "47160c76-59a84fb-f816fca-016076ba78",
+			"guid": "e29ae2b7-642a49e-aaa8aa8-f2c44b1fc1",
 			"line_number": 37,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/time_limiter_test.gd",
 			"suite_name": "time_limiter_test",
@@ -2421,11 +2153,9 @@
 			"attribute_index": -1,
 			"display_name": "test_reset_when_child_finishes",
 			"fully_qualified_name": "test.nodes.decorators.time_limiter_test.test_reset_when_child_finishes",
-			"guid": "f2b91495-ed84455-986edfc-fe1f970cef",
+			"guid": "aea3c810-be0b42d-6871beb-0db132876c",
 			"line_number": 46,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/time_limiter_test.gd",
 			"suite_name": "time_limiter_test",
@@ -2439,11 +2169,9 @@
 			"attribute_index": -1,
 			"display_name": "test_clear_running_child_after_run",
 			"fully_qualified_name": "test.nodes.decorators.time_limiter_test.test_clear_running_child_after_run",
-			"guid": "ae9d9659-b21c497-38a47ca-951b5affea",
+			"guid": "3642e660-48e3463-2b1fc88-6648b00fc1",
 			"line_number": 56,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/time_limiter_test.gd",
 			"suite_name": "time_limiter_test",
@@ -2457,11 +2185,9 @@
 			"attribute_index": -1,
 			"display_name": "test_timer_reset_on_interrupt",
 			"fully_qualified_name": "test.nodes.decorators.time_limiter_test.test_timer_reset_on_interrupt",
-			"guid": "3698ed04-a7d64df-c9789e3-32ac470fb8",
+			"guid": "958e7f92-3bfe406-6b0e913-12c13b83e9",
 			"line_number": 65,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/time_limiter_test.gd",
 			"suite_name": "time_limiter_test",
@@ -2475,11 +2201,9 @@
 			"attribute_index": -1,
 			"display_name": "test_failure",
 			"fully_qualified_name": "test.nodes.decorators.until_fail_test.test_failure",
-			"guid": "6449f298-9d0f45d-b94acc2-0468365117",
+			"guid": "360b28a3-33044c0-98abc7f-89e8f6cc39",
 			"line_number": 33,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/until_fail_test.gd",
 			"suite_name": "until_fail_test",
@@ -2493,11 +2217,9 @@
 			"attribute_index": -1,
 			"display_name": "test_after_run_called_on_success",
 			"fully_qualified_name": "test.nodes.decorators.until_fail_test.test_after_run_called_on_success",
-			"guid": "db8367f5-22534b9-d9014fa-eef02a9092",
+			"guid": "1feb073d-1626452-9bc18cb-3e7a91e21c",
 			"line_number": 47,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/until_fail_test.gd",
 			"suite_name": "until_fail_test",
@@ -2511,11 +2233,9 @@
 			"attribute_index": -1,
 			"display_name": "test_after_run_called_on_failure",
 			"fully_qualified_name": "test.nodes.decorators.until_fail_test.test_after_run_called_on_failure",
-			"guid": "80f65571-0a2c40c-bb7aa79-4ad52486a7",
+			"guid": "1245d868-21ad4d6-2aee981-d6982e5a11",
 			"line_number": 54,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/until_fail_test.gd",
 			"suite_name": "until_fail_test",
@@ -2529,11 +2249,9 @@
 			"attribute_index": -1,
 			"display_name": "test_after_run_not_called_during_running",
 			"fully_qualified_name": "test.nodes.decorators.until_fail_test.test_after_run_not_called_during_running",
-			"guid": "a09960b6-753b4b1-0b04c4e-f4dc7ea081",
+			"guid": "ccd5e40d-feba41f-ab6a4d6-31fbc80ee1",
 			"line_number": 61,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/decorators/until_fail_test.gd",
 			"suite_name": "until_fail_test",
@@ -2547,11 +2265,9 @@
 			"attribute_index": -1,
 			"display_name": "test_erase_existing_key",
 			"fully_qualified_name": "test.nodes.leaves.actions.blackboard_erase_test.test_erase_existing_key",
-			"guid": "085cbc2e-3fe047b-c8874d8-4deb5003db",
+			"guid": "3adaee7a-63cf4e2-29fbdeb-3b6e5e3d56",
 			"line_number": 27,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/actions/blackboard_erase_test.gd",
 			"suite_name": "blackboard_erase_test",
@@ -2565,11 +2281,9 @@
 			"attribute_index": -1,
 			"display_name": "test_erase_non_existing_key",
 			"fully_qualified_name": "test.nodes.leaves.actions.blackboard_erase_test.test_erase_non_existing_key",
-			"guid": "da5ff71b-ce784c4-9a7cf84-579de2f712",
+			"guid": "c4b0e437-2a824e1-0ac30ff-3ecf792aa6",
 			"line_number": 34,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/actions/blackboard_erase_test.gd",
 			"suite_name": "blackboard_erase_test",
@@ -2583,11 +2297,9 @@
 			"attribute_index": -1,
 			"display_name": "test_invalid_key_expression",
 			"fully_qualified_name": "test.nodes.leaves.actions.blackboard_erase_test.test_invalid_key_expression",
-			"guid": "be9873bf-ee3149b-2a55dbd-7e4a1ff766",
+			"guid": "3289e7a6-6fac4b4-19128e1-6986fce66c",
 			"line_number": 39,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/actions/blackboard_erase_test.gd",
 			"suite_name": "blackboard_erase_test",
@@ -2601,11 +2313,9 @@
 			"attribute_index": -1,
 			"display_name": "test_set_to_constant",
 			"fully_qualified_name": "test.nodes.leaves.actions.blackboard_set_test.test_set_to_constant",
-			"guid": "ca5fe267-36a7407-dba1bfb-89778adb47",
+			"guid": "7ccda964-e95e47f-1836acb-14261d8c45",
 			"line_number": 26,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/actions/blackboard_set_test.gd",
 			"suite_name": "blackboard_set_test",
@@ -2619,11 +2329,9 @@
 			"attribute_index": -1,
 			"display_name": "test_copy_key",
 			"fully_qualified_name": "test.nodes.leaves.actions.blackboard_set_test.test_copy_key",
-			"guid": "ba32cad9-9f274fa-484ae32-fcba34cb10",
+			"guid": "e53bca9c-4c6346f-7b9cbf1-5f0395bacf",
 			"line_number": 34,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/actions/blackboard_set_test.gd",
 			"suite_name": "blackboard_set_test",
@@ -2637,11 +2345,9 @@
 			"attribute_index": -1,
 			"display_name": "test_invalid_expression",
 			"fully_qualified_name": "test.nodes.leaves.actions.blackboard_set_test.test_invalid_expression",
-			"guid": "0c2ee16e-d43f463-b8f5fb2-5d9b21e6f4",
+			"guid": "48881874-75e34d1-097e351-6149637c27",
 			"line_number": 42,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/actions/blackboard_set_test.gd",
 			"suite_name": "blackboard_set_test",
@@ -2655,11 +2361,9 @@
 			"attribute_index": -1,
 			"display_name": "test_set_vector3",
 			"fully_qualified_name": "test.nodes.leaves.actions.blackboard_set_test.test_set_vector3",
-			"guid": "a328cb55-0e62469-5912de4-84cd4ad6c9",
+			"guid": "f49a5225-e9534d8-0a36402-02c2c3cbe5",
 			"line_number": 49,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/actions/blackboard_set_test.gd",
 			"suite_name": "blackboard_set_test",
@@ -2673,11 +2377,9 @@
 			"attribute_index": -1,
 			"display_name": "test_invalid_key_expression",
 			"fully_qualified_name": "test.nodes.leaves.actions.blackboard_set_test.test_invalid_key_expression",
-			"guid": "98141660-138c43d-8bab571-737aecea1e",
+			"guid": "25ffffb9-ae0e405-c878b34-87756bdf15",
 			"line_number": 57,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/actions/blackboard_set_test.gd",
 			"suite_name": "blackboard_set_test",
@@ -2691,11 +2393,9 @@
 			"attribute_index": -1,
 			"display_name": "test_invalid_value_expression",
 			"fully_qualified_name": "test.nodes.leaves.actions.blackboard_set_test.test_invalid_value_expression",
-			"guid": "54c3d72f-9a774d6-f9a5aa5-7a4f6185b6",
+			"guid": "c658dfa3-5a8f42c-887c618-5e964f8ce3",
 			"line_number": 63,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/actions/blackboard_set_test.gd",
 			"suite_name": "blackboard_set_test",
@@ -2709,11 +2409,9 @@
 			"attribute_index": -1,
 			"display_name": "test_comparison_operators",
 			"fully_qualified_name": "test.nodes.leaves.conditions.blackboard_compare_test.test_comparison_operators",
-			"guid": "fa1702f2-6d00488-48a1715-fb1cc5a5c1",
+			"guid": "e75e06f8-954e4bf-aac5272-bd26143729",
 			"line_number": 24,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/conditions/blackboard_compare_test.gd",
 			"suite_name": "blackboard_compare_test",
@@ -2727,11 +2425,9 @@
 			"attribute_index": -1,
 			"display_name": "test_blackboard_access",
 			"fully_qualified_name": "test.nodes.leaves.conditions.blackboard_compare_test.test_blackboard_access",
-			"guid": "2bbe7390-097341b-e9fb115-1380c10374",
+			"guid": "00056cdf-95de44f-1acdf44-baf65cc6bb",
 			"line_number": 71,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/conditions/blackboard_compare_test.gd",
 			"suite_name": "blackboard_compare_test",
@@ -2745,11 +2441,9 @@
 			"attribute_index": -1,
 			"display_name": "test_invalid_left_operand_expression",
 			"fully_qualified_name": "test.nodes.leaves.conditions.blackboard_compare_test.test_invalid_left_operand_expression",
-			"guid": "fc7fb411-d5c4497-f94c4d8-62978d6c9a",
+			"guid": "321adccd-235841a-18b5f68-1124768876",
 			"line_number": 82,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/conditions/blackboard_compare_test.gd",
 			"suite_name": "blackboard_compare_test",
@@ -2763,11 +2457,9 @@
 			"attribute_index": -1,
 			"display_name": "test_invalid_right_operand_expression",
 			"fully_qualified_name": "test.nodes.leaves.conditions.blackboard_compare_test.test_invalid_right_operand_expression",
-			"guid": "f121e7e8-feb842d-8ae18af-d004beaed8",
+			"guid": "7f91784c-9dab40c-ca1cef3-6e84f45de1",
 			"line_number": 91,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/conditions/blackboard_compare_test.gd",
 			"suite_name": "blackboard_compare_test",
@@ -2781,11 +2473,9 @@
 			"attribute_index": -1,
 			"display_name": "test_key_exists",
 			"fully_qualified_name": "test.nodes.leaves.conditions.blackboard_has_test.test_key_exists",
-			"guid": "b700ee68-cc3f48f-c943841-1ded0fc6ac",
+			"guid": "9d781caa-4f5c4f3-89649b5-e6f018aa31",
 			"line_number": 27,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/conditions/blackboard_has_test.gd",
 			"suite_name": "blackboard_has_test",
@@ -2799,11 +2489,9 @@
 			"attribute_index": -1,
 			"display_name": "test_variant_key_exists",
 			"fully_qualified_name": "test.nodes.leaves.conditions.blackboard_has_test.test_variant_key_exists",
-			"guid": "d974f1b3-ef6c47d-290c61e-1b3d7c9dca",
+			"guid": "91463522-c75a491-6a8aa07-9bf53a9ec3",
 			"line_number": 34,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/conditions/blackboard_has_test.gd",
 			"suite_name": "blackboard_has_test",
@@ -2817,11 +2505,9 @@
 			"attribute_index": -1,
 			"display_name": "test_key_exists_but_value_null",
 			"fully_qualified_name": "test.nodes.leaves.conditions.blackboard_has_test.test_key_exists_but_value_null",
-			"guid": "5f1a951f-8e3e45a-59ba717-fec498e4e4",
+			"guid": "31007b5f-f15949f-b9e2361-0422665c7d",
 			"line_number": 42,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/conditions/blackboard_has_test.gd",
 			"suite_name": "blackboard_has_test",
@@ -2835,11 +2521,9 @@
 			"attribute_index": -1,
 			"display_name": "test_key_does_not_exist",
 			"fully_qualified_name": "test.nodes.leaves.conditions.blackboard_has_test.test_key_does_not_exist",
-			"guid": "66cc41ec-318f454-c912cce-8645b9873f",
+			"guid": "849072da-aa354b6-7839a0b-474b691333",
 			"line_number": 49,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/conditions/blackboard_has_test.gd",
 			"suite_name": "blackboard_has_test",
@@ -2853,11 +2537,9 @@
 			"attribute_index": -1,
 			"display_name": "test_invalid_key_expression",
 			"fully_qualified_name": "test.nodes.leaves.conditions.blackboard_has_test.test_invalid_key_expression",
-			"guid": "5d726c69-a655425-b871aed-8aeae96173",
+			"guid": "4d52d6da-caeb4b2-aac93f6-b5540cd0fb",
 			"line_number": 54,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/conditions/blackboard_has_test.gd",
 			"suite_name": "blackboard_has_test",
@@ -2871,11 +2553,9 @@
 			"attribute_index": -1,
 			"display_name": "test_invalid_key_expression_wrong_format",
 			"fully_qualified_name": "test.nodes.leaves.conditions.blackboard_has_test.test_invalid_key_expression_wrong_format",
-			"guid": "6de77ca0-44c74bf-ea6e4af-63bc0efabe",
+			"guid": "76efd083-13e7446-59f21db-f02a85129b",
 			"line_number": 61,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/nodes/leaves/conditions/blackboard_has_test.gd",
 			"suite_name": "blackboard_has_test",
@@ -2889,11 +2569,9 @@
 			"attribute_index": -1,
 			"display_name": "test_add_child",
 			"fully_qualified_name": "test.randomized_composites.runtime_changes.runtime_changes_test.test_add_child",
-			"guid": "bbfe807b-c5684b5-f92958a-744878ba37",
+			"guid": "550c8a23-efdd44a-0a593b3-9012167bae",
 			"line_number": 22,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/randomized_composites/runtime_changes/runtime_changes_test.gd",
 			"suite_name": "runtime_changes_test",
@@ -2907,11 +2585,9 @@
 			"attribute_index": -1,
 			"display_name": "test_remove_child",
 			"fully_qualified_name": "test.randomized_composites.runtime_changes.runtime_changes_test.test_remove_child",
-			"guid": "5469c898-9ebc4c8-da621a5-b3fe170a74",
+			"guid": "f25e0851-c96a4c7-3961629-62301c5e40",
 			"line_number": 45,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/randomized_composites/runtime_changes/runtime_changes_test.gd",
 			"suite_name": "runtime_changes_test",
@@ -2925,11 +2601,9 @@
 			"attribute_index": -1,
 			"display_name": "test_rename_child",
 			"fully_qualified_name": "test.randomized_composites.runtime_changes.runtime_changes_test.test_rename_child",
-			"guid": "bb5dfcc1-b5da41e-38e3907-56647227f2",
+			"guid": "53bd4a62-59454d7-e8ecfc4-6665aff7f5",
 			"line_number": 71,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/randomized_composites/runtime_changes/runtime_changes_test.gd",
 			"suite_name": "runtime_changes_test",
@@ -2943,11 +2617,9 @@
 			"attribute_index": -1,
 			"display_name": "test_scene_reload",
 			"fully_qualified_name": "test.randomized_composites.runtime_changes.runtime_changes_test.test_scene_reload",
-			"guid": "b85954dc-11e54ff-29885ed-f2a2fcab91",
+			"guid": "15c0b092-59f24ce-2945c99-00d58025d3",
 			"line_number": 99,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/randomized_composites/runtime_changes/runtime_changes_test.gd",
 			"suite_name": "runtime_changes_test",
@@ -2961,11 +2633,9 @@
 			"attribute_index": -1,
 			"display_name": "test_weights_effecting_sample",
 			"fully_qualified_name": "test.randomized_composites.weighted_sampling.selector_random.selector_random_weights_test.test_weights_effecting_sample",
-			"guid": "d9c27d77-8a564a5-eb742da-ed197a7fa2",
+			"guid": "1ded44e8-3328423-1b5e1c8-1194bc07d0",
 			"line_number": 13,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/randomized_composites/weighted_sampling/selector_random/selector_random_weights_test.gd",
 			"suite_name": "selector_random_weights_test",
@@ -2979,11 +2649,9 @@
 			"attribute_index": -1,
 			"display_name": "test_weights_effecting_sample",
 			"fully_qualified_name": "test.randomized_composites.weighted_sampling.sequence_random_weights.sequence_random_weights_test.test_weights_effecting_sample",
-			"guid": "e8c13ed5-fd4a4c6-1a12dc8-158bf32e0d",
+			"guid": "f2769113-710b40a-d9d893d-9790eea80d",
 			"line_number": 15,
-			"metadata": {
-
-			},
+			"metadata": {},
 			"require_godot_runtime": true,
 			"source_file": "res://test/randomized_composites/weighted_sampling/sequence_random_weights/sequence_random_weights_test.gd",
 			"suite_name": "sequence_random_weights_test",

--- a/addons/gdUnit4/plugin.cfg
+++ b/addons/gdUnit4/plugin.cfg
@@ -3,5 +3,5 @@
 name="gdUnit4"
 description="Unit Testing Framework for Godot Scripts"
 author="Mike Schulze"
-version="6.1.1"
+version="6.1.3"
 script="plugin.gd"

--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -9,21 +9,9 @@ var _editor_code_context_menu: EditorContextMenuPlugin
 
 
 func _enter_tree() -> void:
-	var inferred_declaration: int = ProjectSettings.get_setting("debug/gdscript/warnings/inferred_declaration")
-
-	var is_gdunit_excluded_warnings: bool = false
-	if Engine.get_version_info().hex >= 0x40600:
-		var dirctrory_rules: Dictionary = ProjectSettings.get_setting("debug/gdscript/warnings/directory_rules")
-		if dirctrory_rules.has("res://addons/gdUnit4") and dirctrory_rules["res://addons/gdUnit4"] == 0:
-			is_gdunit_excluded_warnings = true
-	else:
-		is_gdunit_excluded_warnings = ProjectSettings.get_setting("debug/gdscript/warnings/exclude_addons")
-	if !is_gdunit_excluded_warnings and inferred_declaration != 0:
-		printerr("GdUnit4: 'inferred_declaration' is set to Warning/Error!")
-		if Engine.get_version_info().hex >= 0x40600:
-			printerr("GdUnit4 is not 'inferred_declaration' save, you have to excluded the addon (debug/gdscript/warnings/directory_rules)")
-		else:
-			printerr("GdUnit4 is not 'inferred_declaration' save, you have to excluded addons (debug/gdscript/warnings/exclude_addons)")
+	var inferred_declaration := GdUnitSettings.validate_is_inferred_declaration_enabled()
+	if inferred_declaration.is_error():
+		printerr(inferred_declaration.error_message())
 		printerr("Loading GdUnit4 Plugin failed.")
 		return
 

--- a/addons/gdUnit4/plugin.gd.uid
+++ b/addons/gdUnit4/plugin.gd.uid
@@ -1,1 +1,1 @@
-uid://bduuoo74ugn8r
+uid://c42y5hjbrc61k

--- a/addons/gdUnit4/runtest.cmd
+++ b/addons/gdUnit4/runtest.cmd
@@ -51,8 +51,11 @@ if !errorlevel! equ 0 (
     echo done !errorlevel!
 )
 
-:: Run the tests with the filtered arguments
-"!godot_binary!" --path . -s -d res://addons/gdUnit4/bin/GdUnitCmdTool.gd !filtered_args!
+:: Run the tests with the filtered arguments.
+:: --remote-debug tcp://127.0.0.1:0 prevents Godot from activating its local interactive
+:: CLI debugger, which would cause an endless 'debug>' loop on script parse errors.
+:: Port 0 is used intentionally as it is never bound, so the connection is always refused.
+"!godot_binary!" --path . -s -d --remote-debug tcp://127.0.0.1:0 res://addons/gdUnit4/bin/GdUnitCmdTool.gd !filtered_args!
 set exit_code=%ERRORLEVEL%
 echo Run tests ends with %exit_code%
 

--- a/addons/gdUnit4/runtest.sh
+++ b/addons/gdUnit4/runtest.sh
@@ -51,8 +51,11 @@ if echo "$GODOT_VERSION" | grep -i "mono" > /dev/null; then
     echo "done $?"
 fi
 
-# Run the tests with the filtered arguments
-"$godot_binary" --path . -s -d res://addons/gdUnit4/bin/GdUnitCmdTool.gd $filtered_args
+# Run the tests with the filtered arguments.
+# --remote-debug tcp://127.0.0.1:0 prevents Godot from activating its local interactive
+# CLI debugger, which would cause an endless 'debug>' loop on script parse errors.
+# Port 0 is used intentionally as it is never bound, so the connection is always refused.
+"$godot_binary" --path . -s -d --remote-debug tcp://127.0.0.1:0 res://addons/gdUnit4/bin/GdUnitCmdTool.gd $filtered_args
 exit_code=$?
 echo "Run tests ends with $exit_code"
 

--- a/addons/gdUnit4/src/Comparator.gd.uid
+++ b/addons/gdUnit4/src/Comparator.gd.uid
@@ -1,1 +1,1 @@
-uid://ca70wxvy13ijo
+uid://c0k76pies4xf5

--- a/addons/gdUnit4/src/GdUnitArrayAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitArrayAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://bb7pfi8hocfwj
+uid://o33uq0jpumvn

--- a/addons/gdUnit4/src/GdUnitAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://bvnrety6qt1o5
+uid://cier53es2d26q

--- a/addons/gdUnit4/src/GdUnitAwaiter.gd.uid
+++ b/addons/gdUnit4/src/GdUnitAwaiter.gd.uid
@@ -1,1 +1,1 @@
-uid://65xbqy26rb4d
+uid://e06l2qjqhcpe

--- a/addons/gdUnit4/src/GdUnitBoolAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitBoolAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://dkxxknybvsygu
+uid://ve2k6d8jcjxo

--- a/addons/gdUnit4/src/GdUnitConstants.gd.uid
+++ b/addons/gdUnit4/src/GdUnitConstants.gd.uid
@@ -1,1 +1,1 @@
-uid://dpqlnnj80bhym
+uid://b3ps530s33vh7

--- a/addons/gdUnit4/src/GdUnitDictionaryAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitDictionaryAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://dkkmfkuev0cx7
+uid://dljvemhxynm85

--- a/addons/gdUnit4/src/GdUnitFailureAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitFailureAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://b4k2cp2gpxik0
+uid://jjfon11f81k2

--- a/addons/gdUnit4/src/GdUnitFileAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitFileAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://cd0iuqqhgnxdk
+uid://bkwbsmcx4auja

--- a/addons/gdUnit4/src/GdUnitFloatAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitFloatAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://bmh7t0fveiagu
+uid://cykil04r0gm3y

--- a/addons/gdUnit4/src/GdUnitFuncAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitFuncAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://yqjd8phv4hsl
+uid://bs1ixo811gij8

--- a/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://lpqlgyg5bmq5
+uid://crk7q3c6238j3

--- a/addons/gdUnit4/src/GdUnitIntAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitIntAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://ceyfrsp0dawmu
+uid://c7gduckmr7hxo

--- a/addons/gdUnit4/src/GdUnitObjectAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitObjectAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://06vxgkds37ef
+uid://xq5r8w4huqsn

--- a/addons/gdUnit4/src/GdUnitResultAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitResultAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://byvyfivj2ocp5
+uid://clf8ja6nmjedb

--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd.uid
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd.uid
@@ -1,1 +1,1 @@
-uid://cgjg681kniddf
+uid://depor3yqlfrrh

--- a/addons/gdUnit4/src/GdUnitSignalAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitSignalAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://1ck5pjvv3fqf
+uid://cota7xtpxhuu2

--- a/addons/gdUnit4/src/GdUnitStringAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitStringAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://tgj3ucvyiolk
+uid://bs6xrgf02ehoa

--- a/addons/gdUnit4/src/GdUnitTestSuite.gd.uid
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd.uid
@@ -1,1 +1,1 @@
-uid://bjl1s755e1mxt
+uid://cno34k3firegs

--- a/addons/gdUnit4/src/GdUnitTuple.gd.uid
+++ b/addons/gdUnit4/src/GdUnitTuple.gd.uid
@@ -1,1 +1,1 @@
-uid://chal46hkwp1fy
+uid://cnl40dmqikp0k

--- a/addons/gdUnit4/src/GdUnitValueExtractor.gd.uid
+++ b/addons/gdUnit4/src/GdUnitValueExtractor.gd.uid
@@ -1,1 +1,1 @@
-uid://d0xsa32s2yku2
+uid://cbn8m3utyomlu

--- a/addons/gdUnit4/src/GdUnitVectorAssert.gd.uid
+++ b/addons/gdUnit4/src/GdUnitVectorAssert.gd.uid
@@ -1,1 +1,1 @@
-uid://b6s2mnr10s6rx
+uid://chfdu5n1ggxu8

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd.uid
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd.uid
@@ -1,1 +1,1 @@
-uid://dbhlfd2jdqq11
+uid://b86aaihvmrhcg

--- a/addons/gdUnit4/src/asserts/GdAssertReports.gd.uid
+++ b/addons/gdUnit4/src/asserts/GdAssertReports.gd.uid
@@ -1,1 +1,1 @@
-uid://duo4owqiagd3v
+uid://cp6mkw5kv3sno

--- a/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd.uid
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd.uid
@@ -1,1 +1,1 @@
-uid://cydbh62vhd2ae
+uid://s2pjiqbgrary

--- a/addons/gdUnit4/src/asserts/GdUnitAssertions.gd.uid
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertions.gd.uid
@@ -1,1 +1,1 @@
-uid://13anicl1vgym
+uid://b3irvvjrdce7k

--- a/addons/gdUnit4/src/core/GdArrayTools.gd.uid
+++ b/addons/gdUnit4/src/core/GdArrayTools.gd.uid
@@ -1,1 +1,1 @@
-uid://5eq0x5wfmvhp
+uid://drdsteisb57tp

--- a/addons/gdUnit4/src/core/GdDiffTool.gd.uid
+++ b/addons/gdUnit4/src/core/GdDiffTool.gd.uid
@@ -1,1 +1,1 @@
-uid://dwtvt84me7miy
+uid://borp0t5prxafx

--- a/addons/gdUnit4/src/core/GdObjects.gd.uid
+++ b/addons/gdUnit4/src/core/GdObjects.gd.uid
@@ -1,1 +1,1 @@
-uid://bxeqq5bdai77h
+uid://djbcrwn502w10

--- a/addons/gdUnit4/src/core/GdUnit4Version.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnit4Version.gd.uid
@@ -1,1 +1,1 @@
-uid://m2cfbl0b225h
+uid://cds1odrunhfwb

--- a/addons/gdUnit4/src/core/GdUnitFileAccess.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitFileAccess.gd.uid
@@ -1,1 +1,1 @@
-uid://j61avicvxnpk
+uid://b583nkpo5gsbv

--- a/addons/gdUnit4/src/core/GdUnitProperty.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitProperty.gd.uid
@@ -1,1 +1,1 @@
-uid://2kfs6nl3oc6p
+uid://y63qjtddwbra

--- a/addons/gdUnit4/src/core/GdUnitResult.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitResult.gd.uid
@@ -1,1 +1,1 @@
-uid://bycl30fxkp8kc
+uid://cq5us1sxt6gy5

--- a/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd.uid
@@ -1,1 +1,1 @@
-uid://ddha3p2ku64kp
+uid://cmln0rilp70m0

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd.uid
@@ -1,1 +1,1 @@
-uid://bxtw3kpm27853
+uid://7b3a8dmgabj1

--- a/addons/gdUnit4/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit4/src/core/GdUnitSettings.gd
@@ -40,6 +40,23 @@ const CATEGORY_LOGGING := "debug/file_logging/"
 const STDOUT_ENABLE_TO_FILE = CATEGORY_LOGGING + "enable_file_logging"
 const STDOUT_WITE_TO_FILE = CATEGORY_LOGGING + "log_path"
 
+# Godot GDScript warning settings
+const CATEGORY_GDSCRIPT_WARNINGS := "debug/gdscript/warnings/"
+const GDSCRIPT_WARNINGS_INFERRED_DECLARATION := CATEGORY_GDSCRIPT_WARNINGS + "inferred_declaration"
+const GDSCRIPT_WARNINGS_EXCLUDE_ADDONS := CATEGORY_GDSCRIPT_WARNINGS + "exclude_addons"
+const GDSCRIPT_WARNINGS_DIRECTORY_RULES := CATEGORY_GDSCRIPT_WARNINGS + "directory_rules"
+
+enum GdScriptWarningMode {
+	IGNORE = 0,
+	WARN = 1,
+	ERROR = 2,
+}
+
+enum GdScriptWarningDirectoryMode {
+	EXCLUDE = 0,
+	INCLUDE = 1,
+}
+
 
 # GdUnit Templates
 const TEMPLATES = MAIN_CATEGORY + "/templates"
@@ -89,7 +106,7 @@ const DEFAULT_SERVER_TIMEOUT :int = 30
 # test case runtime timeout in seconds
 const DEFAULT_TEST_TIMEOUT :int = 60*5
 # the folder to create new test-suites
-const DEFAULT_TEST_LOOKUP_FOLDER := "test"
+const DEFAULT_TEST_LOOKUP_FOLDER :String = "test"
 
 # help texts
 const HELP_TEST_LOOKUP_FOLDER := "Subfolder where test suites are located (or empty to use source folder directly)"
@@ -100,8 +117,7 @@ enum NAMING_CONVENTIONS {
 	PASCAL_CASE,
 }
 
-
-const _VALUE_SET_SEPARATOR = "\f" # ASCII Form-feed character (AKA page break)
+static var _property_help :Dictionary[String, String] = {}
 
 
 static func setup() -> void:
@@ -163,23 +179,36 @@ static func create_shortcut_properties_if_need() -> void:
 	create_property_if_need(SHORTCUT_FILESYSTEM_RUN_TEST_DEBUG, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.RUN_TESTSUITE_DEBUG), "Run all test suites in the selected folder or file (Debug)")
 
 
-static func create_property_if_need(name :String, default :Variant, help :="", value_set := PackedStringArray()) -> void:
-	if not ProjectSettings.has_setting(name):
+static func create_property_if_need(
+		property_name: String,
+		default_value: Variant,
+		help_text := "",
+		value_set := PackedStringArray()) -> void:
+
+	if not ProjectSettings.has_setting(property_name):
 		#prints("GdUnit4: Set inital settings '%s' to '%s'." % [name, str(default)])
-		ProjectSettings.set_setting(name, default)
+		ProjectSettings.set_setting(property_name, default_value)
 
-	ProjectSettings.set_initial_value(name, default)
-	help = help if value_set.is_empty() else "%s%s%s" % [help, _VALUE_SET_SEPARATOR, value_set]
-	set_help(name, default, help)
+	ProjectSettings.set_initial_value(property_name, default_value)
+	set_property_info(property_name, default_value, value_set)
+	set_property_help(property_name, help_text)
 
 
-static func set_help(property_name :String, value :Variant, help :String) -> void:
-	ProjectSettings.add_property_info({
+static func set_property_info(property_name: String, value: Variant, value_set: PackedStringArray) -> void:
+	var info := {
 		"name": property_name,
 		"type": typeof(value),
-		"hint": PROPERTY_HINT_TYPE_STRING,
-		"hint_string": help
-	})
+		"hint": PROPERTY_HINT_NONE,
+		"hint_string": "",
+	}
+	if not value_set.is_empty():
+		info["hint"] = PROPERTY_HINT_ENUM
+		info["hint_string"] = ",".join(value_set)
+	ProjectSettings.add_property_info(info)
+
+
+static func set_property_help(property_name: String, help_text: String) -> void:
+	_property_help[property_name] = help_text
 
 
 static func get_setting(name :String, default :Variant) -> Variant:
@@ -324,6 +353,32 @@ static func is_log_enabled() -> bool:
 	return ProjectSettings.get_setting(STDOUT_ENABLE_TO_FILE)
 
 
+static func validate_is_inferred_declaration_enabled() -> GdUnitResult:
+	if ProjectSettings.get_setting(GDSCRIPT_WARNINGS_INFERRED_DECLARATION) == GdScriptWarningMode.IGNORE:
+		return GdUnitResult.success()
+
+	if Engine.get_version_info().hex >= 0x40600:
+		var directory_rules: Dictionary = ProjectSettings.get_setting(GDSCRIPT_WARNINGS_DIRECTORY_RULES)
+		# Find the most specific matching rule (longest path wins)
+		var best_match := ""
+		for path: String in directory_rules.keys():
+			if "res://addons/gdUnit4".begins_with(path) and path.length() > best_match.length():
+				best_match = path
+		var is_excluded :bool = not best_match.is_empty() and directory_rules[best_match] == GdScriptWarningDirectoryMode.EXCLUDE
+		if not is_excluded:
+			return GdUnitResult.error("""
+				GdUnit4: 'inferred_declaration' is set to Warning/Error!
+				GdUnit4 is not 'inferred_declaration' safe, you have to exclude the addon (debug/gdscript/warnings/directory_rules)
+				""".dedent().strip_edges())
+	else:
+		if not ProjectSettings.get_setting(GDSCRIPT_WARNINGS_EXCLUDE_ADDONS):
+			return GdUnitResult.error("""
+				GdUnit4: 'inferred_declaration' is set to Warning/Error!
+				GdUnit4 is not 'inferred_declaration' safe, you have to exclude addons (debug/gdscript/warnings/exclude_addons)
+				""".dedent().strip_edges())
+	return GdUnitResult.success()
+
+
 static func list_settings(category: String) -> Array[GdUnitProperty]:
 	var settings: Array[GdUnitProperty] = []
 	for property in ProjectSettings.get_property_list():
@@ -331,25 +386,6 @@ static func list_settings(category: String) -> Array[GdUnitProperty]:
 		if property_name.begins_with(category):
 			settings.append(build_property(property_name, property))
 	return settings
-
-
-static func extract_value_set_from_help(value :String) -> PackedStringArray:
-	var split_value := value.split(_VALUE_SET_SEPARATOR)
-	if not split_value.size() > 1:
-		return PackedStringArray()
-
-	var regex := RegEx.new()
-	@warning_ignore("return_value_discarded")
-	regex.compile("\\[(.+)\\]")
-	var matches := regex.search_all(split_value[1])
-	if matches.is_empty():
-		return PackedStringArray()
-	var values: String = matches[0].get_string(1)
-	return values.replacen(" ", "").replacen("\"", "").split(",", false)
-
-
-static func extract_help_text(value :String) -> String:
-	return value.split(_VALUE_SET_SEPARATOR)[0]
 
 
 static func update_property(property :GdUnitProperty) -> Variant:
@@ -415,9 +451,10 @@ static func build_property(property_name: String, property: Dictionary) -> GdUni
 	var value: Variant = ProjectSettings.get_setting(property_name)
 	var value_type: int = property["type"]
 	var default: Variant = ProjectSettings.property_get_revert(property_name)
-	var help: String = property["hint_string"]
-	var value_set := extract_value_set_from_help(help)
-	return GdUnitProperty.new(property_name, value_type, value, default, extract_help_text(help), value_set)
+	var hint_string: String = property["hint_string"]
+	var value_set := PackedStringArray() if hint_string.is_empty() else hint_string.split(",")
+	var help_text :String = _property_help.get(property_name, "")
+	return GdUnitProperty.new(property_name, value_type, value, default, help_text, value_set)
 
 
 static func migrate_property(old_property :String, new_property :String, default_value :Variant, help :String, converter := Callable()) -> void:
@@ -428,16 +465,7 @@ static func migrate_property(old_property :String, new_property :String, default
 	var value :Variant = converter.call(property.value()) if converter.is_valid() else property.value()
 	ProjectSettings.set_setting(new_property, value)
 	ProjectSettings.set_initial_value(new_property, default_value)
-	set_help(new_property, value, help)
+	set_property_help(new_property, help)
+	set_property_info(new_property, value, [])
 	ProjectSettings.clear(old_property)
 	prints("Successfully migrated property '%s' -> '%s' value: %s" % [old_property, new_property, value])
-
-
-static func dump_to_tmp() -> void:
-	@warning_ignore("return_value_discarded")
-	ProjectSettings.save_custom("user://project_settings.godot")
-
-
-static func restore_dump_from_tmp() -> void:
-	@warning_ignore("return_value_discarded")
-	DirAccess.copy_absolute("user://project_settings.godot", "res://project.godot")

--- a/addons/gdUnit4/src/core/GdUnitSettings.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitSettings.gd.uid
@@ -1,1 +1,1 @@
-uid://bv004y6x1moyo
+uid://q3waj6u0wmgp

--- a/addons/gdUnit4/src/core/GdUnitSignalAwaiter.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitSignalAwaiter.gd.uid
@@ -1,1 +1,1 @@
-uid://xphsu5pqg5bf
+uid://flk1emupwic1

--- a/addons/gdUnit4/src/core/GdUnitSignalCollector.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitSignalCollector.gd.uid
@@ -1,1 +1,1 @@
-uid://bjchxvn7s0ouu
+uid://chhw1fcchv85j

--- a/addons/gdUnit4/src/core/GdUnitSignals.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitSignals.gd.uid
@@ -1,1 +1,1 @@
-uid://bverd0smxo14x
+uid://clv7yogerm7e7

--- a/addons/gdUnit4/src/core/GdUnitSingleton.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitSingleton.gd.uid
@@ -1,1 +1,1 @@
-uid://cttycfsd5pws4
+uid://dxbohsh6bolub

--- a/addons/gdUnit4/src/core/GdUnitTestResourceLoader.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitTestResourceLoader.gd.uid
@@ -1,1 +1,1 @@
-uid://dijywh8dats7m
+uid://fuj1uqyp4uno

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteBuilder.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteBuilder.gd.uid
@@ -1,1 +1,1 @@
-uid://bh5cpr2ix4agr
+uid://clh0hijmxeyfk

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd.uid
@@ -1,1 +1,1 @@
-uid://b52dy3vgxi1c5
+uid://cpwn1ihls030a

--- a/addons/gdUnit4/src/core/GdUnitTools.gd.uid
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd.uid
@@ -1,1 +1,1 @@
-uid://bgncark6ldufj
+uid://bcwkv6xpbgpj0

--- a/addons/gdUnit4/src/core/LocalTime.gd.uid
+++ b/addons/gdUnit4/src/core/LocalTime.gd.uid
@@ -1,1 +1,1 @@
-uid://bjeqb6qy12drp
+uid://dm7rfb58xoaf6

--- a/addons/gdUnit4/src/core/_TestCase.gd.uid
+++ b/addons/gdUnit4/src/core/_TestCase.gd.uid
@@ -1,1 +1,1 @@
-uid://d4knvydfqs1ih
+uid://y7l4ppwmnk32

--- a/addons/gdUnit4/src/core/attributes/TestCaseAttribute.gd.uid
+++ b/addons/gdUnit4/src/core/attributes/TestCaseAttribute.gd.uid
@@ -1,1 +1,1 @@
-uid://dlubkgpamdsn4
+uid://bgi63a4dfwo53

--- a/addons/gdUnit4/src/core/command/GdUnitBaseCommand.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitBaseCommand.gd.uid
@@ -1,1 +1,1 @@
-uid://cswkkmj7xy4fr
+uid://cw5h1dti0km

--- a/addons/gdUnit4/src/core/command/GdUnitCommandFileSystem.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandFileSystem.gd.uid
@@ -1,1 +1,1 @@
-uid://dv85tdkhc5xc3
+uid://7bdinyu0wvgb

--- a/addons/gdUnit4/src/core/command/GdUnitCommandFileSystemDebugTests.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandFileSystemDebugTests.gd.uid
@@ -1,1 +1,1 @@
-uid://b3f2q4okdrs7y
+uid://cgcj7gj0qaqcf

--- a/addons/gdUnit4/src/core/command/GdUnitCommandFileSystemRunTests.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandFileSystemRunTests.gd.uid
@@ -1,1 +1,1 @@
-uid://b6q2233rqcdes
+uid://hri12pmaxevt

--- a/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
@@ -48,7 +48,7 @@ func _notification(what: int) -> void:
 
 
 func _do_process() -> void:
-	# Do stop test execution when the user has stoped the main scene manually
+	# Do stop test execution when the user has stoped the test runner manually by hit the Godot editor stop button
 	if test_session_command._is_debug and test_session_command.is_running() and not EditorInterface.is_playing_scene():
 		if GdUnitSettings.is_verbose_assert_warnings():
 			print_debug("Test Runner scene was stopped manually, force stopping the current test run!")

--- a/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd.uid
@@ -1,1 +1,1 @@
-uid://bny5a2j154abe
+uid://bphh5jlghtkdp

--- a/addons/gdUnit4/src/core/command/GdUnitCommandInspectorDebugTests.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandInspectorDebugTests.gd.uid
@@ -1,1 +1,1 @@
-uid://bbk581r1psi8s
+uid://bqgraxrkiu13k

--- a/addons/gdUnit4/src/core/command/GdUnitCommandInspectorRerunTestsUntilFailure.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandInspectorRerunTestsUntilFailure.gd.uid
@@ -1,1 +1,1 @@
-uid://cw8d5ecv2y7av
+uid://brajy5vs7pgbr

--- a/addons/gdUnit4/src/core/command/GdUnitCommandInspectorRunTests.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandInspectorRunTests.gd.uid
@@ -1,1 +1,1 @@
-uid://b7kbv0eus2ugy
+uid://cy6bygfq4k634

--- a/addons/gdUnit4/src/core/command/GdUnitCommandInspectorTreeCollapse.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandInspectorTreeCollapse.gd.uid
@@ -1,1 +1,1 @@
-uid://dr6aej7k6mew5
+uid://bdffpbt4njspc

--- a/addons/gdUnit4/src/core/command/GdUnitCommandInspectorTreeExpand.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandInspectorTreeExpand.gd.uid
@@ -1,1 +1,1 @@
-uid://dmetwq70lqb3v
+uid://cj7go5lrw6j53

--- a/addons/gdUnit4/src/core/command/GdUnitCommandRunTestsOverall.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandRunTestsOverall.gd.uid
@@ -1,1 +1,1 @@
-uid://k5na6oqamsfj
+uid://5cboijgkcshd

--- a/addons/gdUnit4/src/core/command/GdUnitCommandScriptEditor.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandScriptEditor.gd.uid
@@ -1,1 +1,1 @@
-uid://yy77vt28e8sn
+uid://ltuagcds3rig

--- a/addons/gdUnit4/src/core/command/GdUnitCommandScriptEditorCreateTest.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandScriptEditorCreateTest.gd.uid
@@ -1,1 +1,1 @@
-uid://bp2krb6fdxvpv
+uid://c41dulivqaryg

--- a/addons/gdUnit4/src/core/command/GdUnitCommandScriptEditorDebugTests.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandScriptEditorDebugTests.gd.uid
@@ -1,1 +1,1 @@
-uid://bhqkg1ciewrou
+uid://dkjsqler15pgr

--- a/addons/gdUnit4/src/core/command/GdUnitCommandScriptEditorRunTests.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandScriptEditorRunTests.gd.uid
@@ -1,1 +1,1 @@
-uid://ohh8x6wljivj
+uid://dqnk0620rfbm7

--- a/addons/gdUnit4/src/core/command/GdUnitCommandStopTestSession.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandStopTestSession.gd.uid
@@ -1,1 +1,1 @@
-uid://dthpsdne0x5ew
+uid://mfwl1eiak1fu

--- a/addons/gdUnit4/src/core/command/GdUnitCommandTestSession.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandTestSession.gd
@@ -35,15 +35,13 @@ func stop() -> void:
 
 	if _is_debug and EditorInterface.is_playing_scene():
 		EditorInterface.stop_playing_scene()
-		# We need finaly to send the test session close event because the current run is hard aborted.
-		GdUnitSignals.instance().gdunit_event.emit(GdUnitSessionClose.new())
 	elif OS.is_process_running(_current_runner_process_id):
 		var result := OS.kill(_current_runner_process_id)
 		if result != OK:
 			push_error("ERROR checked stopping GdUnit Test Runner. error code: %s" % result)
 		_current_runner_process_id = -1
-		# We need finaly to send the test session close event because the current run is hard aborted.
-		GdUnitSignals.instance().gdunit_event.emit(GdUnitSessionClose.new())
+	# We need finaly to send the test session close event because the current run is hard aborted.
+	GdUnitSignals.instance().gdunit_event.emit(GdUnitSessionClose.new())
 
 
 ## Forces the running scene to unpause when the debugger hits a breakpoint.[br]

--- a/addons/gdUnit4/src/core/command/GdUnitCommandTestSession.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandTestSession.gd.uid
@@ -1,1 +1,1 @@
-uid://8720s4iqqktl
+uid://ddn7su0lb86ic

--- a/addons/gdUnit4/src/core/command/GdUnitShortcut.gd.uid
+++ b/addons/gdUnit4/src/core/command/GdUnitShortcut.gd.uid
@@ -1,1 +1,1 @@
-uid://dctta8yb8myvp
+uid://cpgkipp3rlxvy

--- a/addons/gdUnit4/src/core/discovery/GdUnitGUID.gd.uid
+++ b/addons/gdUnit4/src/core/discovery/GdUnitGUID.gd.uid
@@ -1,1 +1,1 @@
-uid://woptrmtubm02
+uid://d0lnwostvx7qp

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd.uid
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd.uid
@@ -1,1 +1,1 @@
-uid://dqv0v5bmpnqvo
+uid://dudnxwsr415wd

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd.uid
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd.uid
@@ -1,1 +1,1 @@
-uid://cswsqvbj1wkbq
+uid://2l1j1wp3h7x7

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverSink.gd.uid
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverSink.gd.uid
@@ -1,1 +1,1 @@
-uid://dltfmiqmto4sc
+uid://pmkltrv7v75g

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd.uid
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd.uid
@@ -1,1 +1,1 @@
-uid://bhn5aljh3eh2c
+uid://c30olxvlljq75

--- a/addons/gdUnit4/src/core/event/GdUnitEvent.gd.uid
+++ b/addons/gdUnit4/src/core/event/GdUnitEvent.gd.uid
@@ -1,1 +1,1 @@
-uid://cpldpbhgudsag
+uid://cqc4qrrn7fx8a

--- a/addons/gdUnit4/src/core/event/GdUnitEventTestDiscoverEnd.gd.uid
+++ b/addons/gdUnit4/src/core/event/GdUnitEventTestDiscoverEnd.gd.uid
@@ -1,1 +1,1 @@
-uid://becojbr4un5v3
+uid://cq4p1c6ml6wc1

--- a/addons/gdUnit4/src/core/event/GdUnitEventTestDiscoverStart.gd.uid
+++ b/addons/gdUnit4/src/core/event/GdUnitEventTestDiscoverStart.gd.uid
@@ -1,1 +1,1 @@
-uid://cl0qtbb3qdxwq
+uid://dwgwermqw3gxh

--- a/addons/gdUnit4/src/core/event/GdUnitSessionClose.gd.uid
+++ b/addons/gdUnit4/src/core/event/GdUnitSessionClose.gd.uid
@@ -1,1 +1,1 @@
-uid://cuxxkokby7oxu
+uid://j4utqh4yq70k

--- a/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
@@ -24,6 +24,9 @@ var _flaky_test_check := GdUnitSettings.is_test_flaky_check_enabled()
 var _flaky_test_retries := GdUnitSettings.get_flaky_max_retries()
 
 
+var _settings_snapshot: GdUnitProjectSettingsSnapshot = null
+
+
 var error_monitor: GodotGdErrorMonitor = null:
 	get:
 		if _parent_context != null:
@@ -120,6 +123,18 @@ func get_test_case_name() -> StringName:
 	if _test_case_name.is_empty():
 		return test_case._test_case.display_name
 	return _test_case_name
+
+
+func save_project_settings() -> void:
+	if _settings_snapshot == null:
+		_settings_snapshot = GdUnitProjectSettingsSnapshot.new()
+	_settings_snapshot.save()
+
+
+func restore_project_settings() -> void:
+	if _settings_snapshot == null:
+		return
+	_settings_snapshot.restore()
 
 
 func error_monitor_start() -> void:

--- a/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd.uid
+++ b/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd.uid
@@ -1,1 +1,1 @@
-uid://cljds2cgglwrc
+uid://cxoq6lcavlc6p

--- a/addons/gdUnit4/src/core/execution/GdUnitMemoryObserver.gd.uid
+++ b/addons/gdUnit4/src/core/execution/GdUnitMemoryObserver.gd.uid
@@ -1,1 +1,1 @@
-uid://budgjoc6da01j
+uid://ctt1lpfne6tfx

--- a/addons/gdUnit4/src/core/execution/GdUnitProjectSettingsSnapshot.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitProjectSettingsSnapshot.gd
@@ -1,0 +1,36 @@
+## Captures and restores all in-memory [ProjectSettings] values around a single
+## stage of test execution.[br]
+## Each [GdUnitExecutionContext] owns one instance. Suite-level and test-level
+## isolation are achieved by the two separate contexts rather than by stacking:[br]
+## [codeblock]
+##   GdUnitTestSuiteExecutionStage  -> save()   (before before())
+##     GdUnitTestCaseExecutionStage -> save()   (before before_test())
+##     GdUnitTestCaseExecutionStage -> restore() (after after_test())
+##   GdUnitTestSuiteExecutionStage  -> restore() (after after())
+## [/codeblock]
+class_name GdUnitProjectSettingsSnapshot
+extends RefCounted
+
+
+var _snapshot: Dictionary = {}
+
+
+func save() -> void:
+	_snapshot.clear()
+	for property: Dictionary in ProjectSettings.get_property_list():
+		var name: String = property["name"]
+		if ProjectSettings.has_setting(name):
+			var value: Variant = ProjectSettings.get_setting(name)
+			@warning_ignore("unsafe_method_access")
+			_snapshot[name] = value.duplicate() if (value is Dictionary or value is Array) else value
+
+
+func restore() -> void:
+	for name: String in _snapshot:
+		if not ProjectSettings.has_setting(name):
+			continue
+		var current: Variant = ProjectSettings.get_setting(name)
+		var original: Variant = _snapshot[name]
+		if current != original:
+			ProjectSettings.set_setting(name, original)
+	_snapshot.clear()

--- a/addons/gdUnit4/src/core/execution/GdUnitProjectSettingsSnapshot.gd.uid
+++ b/addons/gdUnit4/src/core/execution/GdUnitProjectSettingsSnapshot.gd.uid
@@ -1,0 +1,1 @@
+uid://wn063dagwypc

--- a/addons/gdUnit4/src/core/execution/GdUnitTestReportCollector.gd.uid
+++ b/addons/gdUnit4/src/core/execution/GdUnitTestReportCollector.gd.uid
@@ -1,1 +1,1 @@
-uid://curlrrucku7sn
+uid://bkau2jan78hwr

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseExecutionStage.gd
@@ -16,6 +16,7 @@ var _stage_fuzzer_test: IGdUnitExecutionStage = GdUnitTestCaseFuzzedExecutionSta
 func _execute(context :GdUnitExecutionContext) -> void:
 	var test_case := context.test_case
 
+	context.save_project_settings()
 	context.error_monitor_start()
 
 	if test_case.is_fuzzed():
@@ -25,6 +26,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 
 	await context.gc()
 	context.error_monitor_stop()
+	context.restore_project_settings()
 
 	# finally free the test instance
 	if is_instance_valid(context.test_case):

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
@@ -21,6 +21,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 	else:
 		@warning_ignore("return_value_discarded")
 		GdUnitMemoryObserver.guard_instance(context.test_suite.__awaiter)
+		context.save_project_settings()
 		await _stage_before.execute(context)
 		for test_case_index in context.test_suite.get_child_count():
 			# iterate only over test cases
@@ -39,6 +40,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 				# and replace it by a clone without function state
 				context.test_suite = await clone_test_suite(context.test_suite)
 		await _stage_after.execute(context)
+		context.restore_project_settings()
 		GdUnitMemoryObserver.unguard_instance(context.test_suite.__awaiter)
 
 	await (Engine.get_main_loop() as SceneTree).process_frame

--- a/addons/gdUnit4/src/core/hooks/GdUnitBaseReporterTestSessionHook.gd.uid
+++ b/addons/gdUnit4/src/core/hooks/GdUnitBaseReporterTestSessionHook.gd.uid
@@ -1,1 +1,1 @@
-uid://d37xqqbnc71nr
+uid://ck0ju6vdqgjy1

--- a/addons/gdUnit4/src/core/hooks/GdUnitHtmlReporterTestSessionHook.gd.uid
+++ b/addons/gdUnit4/src/core/hooks/GdUnitHtmlReporterTestSessionHook.gd.uid
@@ -1,1 +1,1 @@
-uid://cwnew6viljalv
+uid://bqvgc7bidc83w

--- a/addons/gdUnit4/src/core/hooks/GdUnitTestSessionHook.gd.uid
+++ b/addons/gdUnit4/src/core/hooks/GdUnitTestSessionHook.gd.uid
@@ -1,1 +1,1 @@
-uid://cw3pkan8olvdj
+uid://c4gth66abnupb

--- a/addons/gdUnit4/src/core/hooks/GdUnitTestSessionHookService.gd
+++ b/addons/gdUnit4/src/core/hooks/GdUnitTestSessionHookService.gd
@@ -158,9 +158,10 @@ func load_hook_settings() -> void:
 		var enabled := hooks_resource_paths[hock_path]
 
 		# Do not reinstall already installed hooks
-		var existing_hook: GdUnitTestSessionHook = enigne_hooks.filter(func(element: GdUnitTestSessionHook) -> bool:
+		var existing_hooks := enigne_hooks.filter(func(element: GdUnitTestSessionHook) -> bool:
 			return element.get_script().resource_path == hock_path
-		).front()
+		)
+		var existing_hook: GdUnitTestSessionHook = null if existing_hooks.is_empty() else existing_hooks.front()
 		# Applay enabled settings
 		if existing_hook != null:
 			_enable_hook(existing_hook, enabled)

--- a/addons/gdUnit4/src/core/hooks/GdUnitTestSessionHookService.gd.uid
+++ b/addons/gdUnit4/src/core/hooks/GdUnitTestSessionHookService.gd.uid
@@ -1,1 +1,1 @@
-uid://c7mkhhl3ddj2i
+uid://uv242pjvcldm

--- a/addons/gdUnit4/src/core/hooks/GdUnitXMLReporterTestSessionHook.gd.uid
+++ b/addons/gdUnit4/src/core/hooks/GdUnitXMLReporterTestSessionHook.gd.uid
@@ -1,1 +1,1 @@
-uid://btbjbdm13bbmf
+uid://n4x4g03uqnr8

--- a/addons/gdUnit4/src/core/parse/GdClassDescriptor.gd.uid
+++ b/addons/gdUnit4/src/core/parse/GdClassDescriptor.gd.uid
@@ -1,1 +1,1 @@
-uid://c0g6kkpeg8fvp
+uid://dfdplnkft54ia

--- a/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd.uid
+++ b/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd.uid
@@ -1,1 +1,1 @@
-uid://djge6mxnpibc4
+uid://b787jc5wqwahi

--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd.uid
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd.uid
@@ -1,1 +1,1 @@
-uid://bfhpehi7mxcxr
+uid://bcv3grq3neh3q

--- a/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd.uid
+++ b/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd.uid
@@ -1,1 +1,1 @@
-uid://ni7v10l6nkn5
+uid://bij7snvypn6to

--- a/addons/gdUnit4/src/core/parse/GdFunctionParameterSetResolver.gd.uid
+++ b/addons/gdUnit4/src/core/parse/GdFunctionParameterSetResolver.gd.uid
@@ -1,1 +1,1 @@
-uid://4rjggswaungi
+uid://dlnvfshva0prw

--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -37,6 +37,7 @@ var TOKEN_BRACKET_SQUARE_OPEN := Token.new("[")
 var TOKEN_BRACKET_SQUARE_CLOSE := Token.new("]")
 var TOKEN_BRACKET_CURLY_OPEN := Token.new("{")
 var TOKEN_BRACKET_CURLY_CLOSE := Token.new("}")
+var TOKEN_BACKSLASH := Token.new("\\")
 
 
 var OPERATOR_ADD := Operator.new("+")
@@ -49,6 +50,7 @@ var TOKENS :Array[Token] = [
 	TOKEN_SPACE,
 	TOKEN_TABULATOR,
 	TOKEN_NEW_LINE,
+	TOKEN_BACKSLASH,
 	TOKEN_COMMENT,
 	TOKEN_BRACKET_ROUND_OPEN,
 	TOKEN_BRACKET_ROUND_CLOSE,

--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd.uid
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd.uid
@@ -1,1 +1,1 @@
-uid://dordq57aybmhh
+uid://batbam16r2gmt

--- a/addons/gdUnit4/src/core/parse/GdUnitExpressionRunner.gd.uid
+++ b/addons/gdUnit4/src/core/parse/GdUnitExpressionRunner.gd.uid
@@ -1,1 +1,1 @@
-uid://bn2qnmtt7j4u8
+uid://cjohui0v5a0hw

--- a/addons/gdUnit4/src/core/parse/GdUnitTestParameterSetResolver.gd.uid
+++ b/addons/gdUnit4/src/core/parse/GdUnitTestParameterSetResolver.gd.uid
@@ -1,1 +1,1 @@
-uid://cotphsljemq3f
+uid://du046xfulf8eg

--- a/addons/gdUnit4/src/core/report/GdUnitReport.gd.uid
+++ b/addons/gdUnit4/src/core/report/GdUnitReport.gd.uid
@@ -1,1 +1,1 @@
-uid://5uq7ycmqiust
+uid://dm2qw4t5ya8t2

--- a/addons/gdUnit4/src/core/runners/GdUnitScriptErrorCollector.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitScriptErrorCollector.gd
@@ -1,0 +1,66 @@
+## Collects GDScript parse errors.[br]
+## [br]
+## Installed via [method OS.add_logger] so it intercepts [constant ErrorType.ERROR_TYPE_SCRIPT]
+## entries without triggering Godot's interactive CLI debugger.[br]
+## Used by [class GdUnitTestCIRunner] to detect broken user test scripts early
+## and exit with a meaningful error instead of silently skipping them.
+class_name GdUnitScriptErrorCollector
+extends Logger
+
+
+## Holds information about a single captured script error.
+class ScriptError extends RefCounted:
+	var _message: String
+	var _source_file: String
+	var _source_line: int
+
+	func _init(message: String, source_file: String, source_line: int) -> void:
+		_message = message
+		_source_file = source_file
+		_source_line = source_line
+
+	func _to_string() -> String:
+		if _source_file.is_empty():
+			return _message
+		return "%s\n\tat %s:%d" % [_message, _source_file, _source_line]
+
+
+var _errors: Array[ScriptError] = []
+
+
+func _init() -> void:
+	OS.add_logger(self)
+
+
+func _log_error(
+	_function: String,
+	source_file: String,
+	source_line: int,
+	message: String,
+	_rationale: String,
+	_editor_notify: bool,
+	error_type: int,
+	_script_backtraces: Array[ScriptBacktrace]
+	) -> void:
+	if error_type != ErrorType.ERROR_TYPE_SCRIPT:
+		return
+	_errors.append(ScriptError.new(message, source_file, source_line))
+
+
+func _log_message(_message: String, _error: bool) -> void:
+	pass
+
+
+## Returns true if any script errors were captured.
+func has_errors() -> bool:
+	return not _errors.is_empty()
+
+
+## Returns all captured script errors.
+func errors() -> Array[ScriptError]:
+	return _errors
+
+
+## Clears all captured errors.
+func clear() -> void:
+	_errors.clear()

--- a/addons/gdUnit4/src/core/runners/GdUnitScriptErrorCollector.gd.uid
+++ b/addons/gdUnit4/src/core/runners/GdUnitScriptErrorCollector.gd.uid
@@ -1,0 +1,1 @@
+uid://beme7wkhc8c51

--- a/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
@@ -118,7 +118,7 @@ func _notification(what: int) -> void:
 
 
 func init_runner() -> void:
-	init_gd_unit()
+	await init_gd_unit()
 
 
 ## Returns the exit code based on test results.[br]
@@ -383,11 +383,22 @@ func init_gd_unit() -> void:
 			quit(RETURN_ERROR_HEADLESS_NOT_SUPPORTED)
 			return
 
+	var script_error_collector := GdUnitScriptErrorCollector.new()
 	_test_cases = discover_tests()
+
+	# Check for script errors captured during discovery
+	if script_error_collector.has_errors():
+		console_error("Script errors were detected during test discovery!")
+		for error in script_error_collector.errors():
+			console_info("  %s" % error)
+		console_error("Abnormal exit with %d" % RETURN_ERROR_SCRIPT_ERRORS_DETECTED)
+		await quit(RETURN_ERROR_SCRIPT_ERRORS_DETECTED)
+		return
+
 	if _test_cases.is_empty():
 		console_info("No test cases found, abort test run!", Color.YELLOW)
 		console_info("Exit code: %d" % RETURN_SUCCESS, Color.DARK_SALMON)
-		quit(RETURN_SUCCESS)
+		await quit(RETURN_SUCCESS)
 		return
 	_state = RUN
 

--- a/addons/gdUnit4/src/core/runners/GdUnitTestSession.gd.uid
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestSession.gd.uid
@@ -1,1 +1,1 @@
-uid://b37naxwncu2nl
+uid://dkq1w8ip6x0wi

--- a/addons/gdUnit4/src/core/runners/GdUnitTestSessionRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestSessionRunner.gd
@@ -18,6 +18,7 @@ const RETURN_SUCCESS = 0
 const RETURN_ERROR = 100
 const RETURN_ERROR_HEADLESS_NOT_SUPPORTED = 103
 const RETURN_ERROR_GODOT_VERSION_NOT_SUPPORTED = 104
+const RETURN_ERROR_SCRIPT_ERRORS_DETECTED = 105
 const RETURN_WARNING = 101
 
 ## Specifies the Node name under which the runner is registered

--- a/addons/gdUnit4/src/core/templates/test_suite/GdUnitTestSuiteDefaultTemplate.gd.uid
+++ b/addons/gdUnit4/src/core/templates/test_suite/GdUnitTestSuiteDefaultTemplate.gd.uid
@@ -1,1 +1,1 @@
-uid://01uaegsfwhoa
+uid://carrmcg41os1r

--- a/addons/gdUnit4/src/core/templates/test_suite/GdUnitTestSuiteTemplate.gd.uid
+++ b/addons/gdUnit4/src/core/templates/test_suite/GdUnitTestSuiteTemplate.gd.uid
@@ -1,1 +1,1 @@
-uid://tnlrrdk54qpa
+uid://r0wtccwifwt1

--- a/addons/gdUnit4/src/core/thread/GdUnitThreadContext.gd
+++ b/addons/gdUnit4/src/core/thread/GdUnitThreadContext.gd
@@ -30,7 +30,8 @@ func dispose() -> void:
 
 
 func terminate() -> void:
-	_execution_context.terminate()
+	if _execution_context:
+		_execution_context.terminate()
 
 
 func clear_assert() -> void:

--- a/addons/gdUnit4/src/core/thread/GdUnitThreadContext.gd.uid
+++ b/addons/gdUnit4/src/core/thread/GdUnitThreadContext.gd.uid
@@ -1,1 +1,1 @@
-uid://b485tn63cuos
+uid://wpoabjesygre

--- a/addons/gdUnit4/src/core/thread/GdUnitThreadManager.gd.uid
+++ b/addons/gdUnit4/src/core/thread/GdUnitThreadManager.gd.uid
@@ -1,1 +1,1 @@
-uid://ctlsqdd4tpwj4
+uid://dnbvavri05dtk

--- a/addons/gdUnit4/src/core/writers/GdUnitCSIMessageWriter.gd.uid
+++ b/addons/gdUnit4/src/core/writers/GdUnitCSIMessageWriter.gd.uid
@@ -1,1 +1,1 @@
-uid://cdbikmk07d5rg
+uid://3hlqd8sh4eas

--- a/addons/gdUnit4/src/core/writers/GdUnitMessageWriter.gd.uid
+++ b/addons/gdUnit4/src/core/writers/GdUnitMessageWriter.gd.uid
@@ -1,1 +1,1 @@
-uid://dlkfkxu45qadu
+uid://dtlgle6ie4mqu

--- a/addons/gdUnit4/src/core/writers/GdUnitRichTextMessageWriter.gd.uid
+++ b/addons/gdUnit4/src/core/writers/GdUnitRichTextMessageWriter.gd.uid
@@ -1,1 +1,1 @@
-uid://csy8tqy7efxr2
+uid://barsoqh6fab1x

--- a/addons/gdUnit4/src/dotnet/GdUnit4CSharpApiLoader.gd.uid
+++ b/addons/gdUnit4/src/dotnet/GdUnit4CSharpApiLoader.gd.uid
@@ -1,1 +1,1 @@
-uid://nk4275tmrlqh
+uid://bn7wy2xjn7ga6

--- a/addons/gdUnit4/src/fuzzers/Fuzzer.gd.uid
+++ b/addons/gdUnit4/src/fuzzers/Fuzzer.gd.uid
@@ -1,1 +1,1 @@
-uid://l7i147a4f78i
+uid://b74drg6qo5ijn

--- a/addons/gdUnit4/src/matchers/GdUnitArgumentMatcher.gd.uid
+++ b/addons/gdUnit4/src/matchers/GdUnitArgumentMatcher.gd.uid
@@ -1,1 +1,1 @@
-uid://1mqm4qoc7m1q
+uid://bd3oktehgro25

--- a/addons/gdUnit4/src/mocking/GdUnitMock.gd.uid
+++ b/addons/gdUnit4/src/mocking/GdUnitMock.gd.uid
@@ -1,1 +1,1 @@
-uid://bb651fjm77clt
+uid://cfjcmfgxi6chq

--- a/addons/gdUnit4/src/monitor/ErrorLogEntry.gd.uid
+++ b/addons/gdUnit4/src/monitor/ErrorLogEntry.gd.uid
@@ -1,1 +1,1 @@
-uid://b52fac8u71oob
+uid://d18kdqeisbfnt

--- a/addons/gdUnit4/src/monitor/GdUnitMonitor.gd.uid
+++ b/addons/gdUnit4/src/monitor/GdUnitMonitor.gd.uid
@@ -1,1 +1,1 @@
-uid://cxbv220ht8r0s
+uid://ceruvc776ke5b

--- a/addons/gdUnit4/src/monitor/GdUnitOrphanNodeInfo.gd.uid
+++ b/addons/gdUnit4/src/monitor/GdUnitOrphanNodeInfo.gd.uid
@@ -1,1 +1,1 @@
-uid://c57l3cv136otf
+uid://0qrmb47a3o3a

--- a/addons/gdUnit4/src/monitor/GdUnitOrphanNodesMonitor.gd.uid
+++ b/addons/gdUnit4/src/monitor/GdUnitOrphanNodesMonitor.gd.uid
@@ -1,1 +1,1 @@
-uid://ryjb5pbypvv2
+uid://brewrktror4s4

--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd.uid
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd.uid
@@ -1,1 +1,1 @@
-uid://cgyttjah3afgb
+uid://bhpc26h1nwwwp

--- a/addons/gdUnit4/src/network/GdUnitServer.gd.uid
+++ b/addons/gdUnit4/src/network/GdUnitServer.gd.uid
@@ -1,1 +1,1 @@
-uid://qqbnyp4e5rd2
+uid://b1yep5nhpyg3c

--- a/addons/gdUnit4/src/network/GdUnitServerConstants.gd.uid
+++ b/addons/gdUnit4/src/network/GdUnitServerConstants.gd.uid
@@ -1,1 +1,1 @@
-uid://l5nq0vyxf3rh
+uid://claw1d0xh8drr

--- a/addons/gdUnit4/src/network/GdUnitTcpNode.gd.uid
+++ b/addons/gdUnit4/src/network/GdUnitTcpNode.gd.uid
@@ -1,1 +1,1 @@
-uid://ceptogsxbe85g
+uid://b1yrum3ku2orj

--- a/addons/gdUnit4/src/network/GdUnitTcpServer.gd.uid
+++ b/addons/gdUnit4/src/network/GdUnitTcpServer.gd.uid
@@ -1,1 +1,1 @@
-uid://8lmvrgssbq62
+uid://cvtgrikkm4p8q

--- a/addons/gdUnit4/src/network/rpc/RPC.gd.uid
+++ b/addons/gdUnit4/src/network/rpc/RPC.gd.uid
@@ -1,1 +1,1 @@
-uid://clqpcv7vfl5by
+uid://drt8xy61v3sxx

--- a/addons/gdUnit4/src/network/rpc/RPCClientConnect.gd.uid
+++ b/addons/gdUnit4/src/network/rpc/RPCClientConnect.gd.uid
@@ -1,1 +1,1 @@
-uid://7vo4fbwd8iho
+uid://33pb0fqrmyl6

--- a/addons/gdUnit4/src/network/rpc/RPCClientDisconnect.gd.uid
+++ b/addons/gdUnit4/src/network/rpc/RPCClientDisconnect.gd.uid
@@ -1,1 +1,1 @@
-uid://bf2hk545tryxp
+uid://c5bkoihmyowx0

--- a/addons/gdUnit4/src/network/rpc/RPCGdUnitEvent.gd.uid
+++ b/addons/gdUnit4/src/network/rpc/RPCGdUnitEvent.gd.uid
@@ -1,1 +1,1 @@
-uid://dsdvopul4f8di
+uid://d2fihq68prteh

--- a/addons/gdUnit4/src/network/rpc/RPCMessage.gd.uid
+++ b/addons/gdUnit4/src/network/rpc/RPCMessage.gd.uid
@@ -1,1 +1,1 @@
-uid://dqpiqk2bxeapi
+uid://ddq6mb5ldqsan

--- a/addons/gdUnit4/src/reporters/GdUnitReportSummary.gd.uid
+++ b/addons/gdUnit4/src/reporters/GdUnitReportSummary.gd.uid
@@ -1,1 +1,1 @@
-uid://cobf2mqj7kct5
+uid://g875pg43o3vn

--- a/addons/gdUnit4/src/reporters/GdUnitReportWriter.gd.uid
+++ b/addons/gdUnit4/src/reporters/GdUnitReportWriter.gd.uid
@@ -1,1 +1,1 @@
-uid://bxmtc2e08f0al
+uid://5mpa37qy7alb

--- a/addons/gdUnit4/src/reporters/GdUnitTestCaseReport.gd.uid
+++ b/addons/gdUnit4/src/reporters/GdUnitTestCaseReport.gd.uid
@@ -1,1 +1,1 @@
-uid://xof7hime4phe
+uid://cs7c4v2wt4lrr

--- a/addons/gdUnit4/src/reporters/GdUnitTestReporter.gd.uid
+++ b/addons/gdUnit4/src/reporters/GdUnitTestReporter.gd.uid
@@ -1,1 +1,1 @@
-uid://7x8ws4esbecc
+uid://chqixblt0q5sv

--- a/addons/gdUnit4/src/reporters/GdUnitTestSuiteReport.gd.uid
+++ b/addons/gdUnit4/src/reporters/GdUnitTestSuiteReport.gd.uid
@@ -1,1 +1,1 @@
-uid://ucldcy60nevk
+uid://d1p2j3ujjdsh1

--- a/addons/gdUnit4/src/reporters/console/GdUnitConsoleTestReporter.gd.uid
+++ b/addons/gdUnit4/src/reporters/console/GdUnitConsoleTestReporter.gd.uid
@@ -1,1 +1,1 @@
-uid://dhf8pn02q1kwf
+uid://c4q1smdr6uroj

--- a/addons/gdUnit4/src/reporters/html/GdUnitByPathReport.gd
+++ b/addons/gdUnit4/src/reporters/html/GdUnitByPathReport.gd
@@ -2,17 +2,17 @@ class_name GdUnitByPathReport
 extends GdUnitReportSummary
 
 
-func _init(p_path :String, report_summaries :Array[GdUnitReportSummary]) -> void:
+func _init(p_path: String, report_summaries: Array[GdUnitReportSummary]) -> void:
 	_resource_path = p_path
 	_reports = report_summaries
 
 
 # -> Dictionary[String, Array[GdUnitReportSummary]]
-static func sort_reports_by_path(report_summaries :Array[GdUnitReportSummary]) -> Dictionary:
+static func sort_reports_by_path(report_summaries: Array[GdUnitReportSummary]) -> Dictionary:
 	var by_path := Dictionary()
 	for report in report_summaries:
-		var suite_path :String = ProjectSettings.localize_path(report.path())
-		var suite_report :Array[GdUnitReportSummary] = by_path.get(suite_path, [] as Array[GdUnitReportSummary])
+		var suite_path: String = ProjectSettings.localize_path(report.path())
+		var suite_report: Array[GdUnitReportSummary] = by_path.get(suite_path, [] as Array[GdUnitReportSummary])
 		suite_report.append(report)
 		by_path[suite_path] = suite_report
 	return by_path
@@ -22,36 +22,31 @@ func path() -> String:
 	return _resource_path.replace("res://", "").trim_suffix("/")
 
 
-func create_record(report_link :String) -> String:
+func create_record(report_link: String) -> String:
 	return GdUnitHtmlPatterns.build(GdUnitHtmlPatterns.TABLE_RECORD_PATH, self, report_link)
 
 
-func write(report_dir :String) -> String:
+func write(report_dir: String) -> String:
 	calculate_summary()
+	var output_path := GdUnitHtmlPatterns.create_path_output_path(report_dir, path())
 	var template := GdUnitHtmlPatterns.load_template("res://addons/gdUnit4/src/reporters/html/template/folder_report.html")
-	var path_report := GdUnitHtmlPatterns.build(template, self, "")
+	var path_report := GdUnitHtmlPatterns.build(template, self, output_path, GdUnitHtmlPatterns.get_path_as_link(self))
 	path_report = apply_testsuite_reports(report_dir, path_report, _reports)
-
-	var output_path := "%s/path/%s.html" % [report_dir, path().replace("/", ".")]
-	var dir := output_path.get_base_dir()
-	if not DirAccess.dir_exists_absolute(dir):
-		@warning_ignore("return_value_discarded")
-		DirAccess.make_dir_recursive_absolute(dir)
-	FileAccess.open(output_path, FileAccess.WRITE).store_string(path_report)
+	GdUnitHtmlPatterns.write_html_file(output_path, path_report)
 	return output_path
 
 
-func apply_testsuite_reports(report_dir :String, template :String, test_suite_reports :Array[GdUnitReportSummary]) -> String:
+func apply_testsuite_reports(report_dir: String, template: String, test_suite_reports: Array[GdUnitReportSummary]) -> String:
 	var table_records := PackedStringArray()
-	for report:GdUnitTestSuiteReport in test_suite_reports:
-		var report_link := GdUnitHtmlReportWriter.create_output_path(report_dir, report.path(), report.name()).replace(report_dir, "..")
+	for report: GdUnitTestSuiteReport in test_suite_reports:
+		var report_link := GdUnitHtmlPatterns.create_suite_output_path(report_dir, report.path(), report.name()).replace(report_dir, "..")
 		@warning_ignore("return_value_discarded")
 		table_records.append(GdUnitHtmlPatterns.create_suite_record(report_link, report))
 	return template.replace(GdUnitHtmlPatterns.TABLE_BY_TESTSUITES, "\n".join(table_records))
 
 
 func calculate_summary() -> void:
-	for report:GdUnitTestSuiteReport in get_reports():
+	for report: GdUnitTestSuiteReport in get_reports():
 		_error_count += report.error_count()
 		_failure_count += report.failure_count()
 		_orphan_count += report.orphan_count()

--- a/addons/gdUnit4/src/reporters/html/GdUnitByPathReport.gd.uid
+++ b/addons/gdUnit4/src/reporters/html/GdUnitByPathReport.gd.uid
@@ -1,1 +1,1 @@
-uid://cfyma14vknf7q
+uid://cuvb21mqrthwx

--- a/addons/gdUnit4/src/reporters/html/GdUnitHtmlPatterns.gd
+++ b/addons/gdUnit4/src/reporters/html/GdUnitHtmlPatterns.gd
@@ -3,7 +3,7 @@ extends RefCounted
 
 const TABLE_RECORD_TESTSUITE = """
 								<tr class="${report_state}">
-									<td><a href=${report_link}>${testsuite_name}</a></td>
+									<td><a href="${report_link}">${testsuite_name}</a></td>
 									<td><span class="status status-${report_state}">${report_state_label}</span></td>
 									<td>${test_count}</td>
 									<td>${skipped_count}</td>
@@ -79,8 +79,8 @@ ${failure-report}
 """
 
 const CHARACTERS_TO_ENCODE := {
-	'<' : '&lt;',
-	'>' : '&gt;'
+	'<': '&lt;',
+	'>': '&gt;'
 }
 
 const TABLE_BY_PATHS = "${report_table_paths}"
@@ -121,10 +121,10 @@ static func current_date() -> String:
 	return Time.get_datetime_string_from_system(true, true)
 
 
-static func build(template: String, report: GdUnitReportSummary, report_link: String) -> String:
+static func build(template: String, report: GdUnitReportSummary, report_link: String, breadcrumb_path_link := "") -> String:
 	return template\
 		.replace(PATH, get_report_path(report))\
-		.replace(BREADCRUMP_PATH_LINK, get_path_as_link(report))\
+		.replace(BREADCRUMP_PATH_LINK, breadcrumb_path_link)\
 		.replace(RESOURCE_PATH, report.get_resource_path())\
 		.replace(TESTSUITE_NAME, html_encoded(report.name()))\
 		.replace(TESTSUITE_COUNT, str(report.suite_count()))\
@@ -147,12 +147,32 @@ static func build(template: String, report: GdUnitReportSummary, report_link: St
 		.replace(BUILD_DATE, current_date())
 
 
-static func load_template(template_name :String) -> String:
+static func load_template(template_name: String) -> String:
 	return FileAccess.open(template_name, FileAccess.READ).get_as_text()
 
 
+static func normalize_path(path: String) -> String:
+	return path.replace("/", ".").replace(" ", "_")
+
+
+static func create_suite_output_path(report_dir: String, path: String, name: String) -> String:
+	return "%s/test_suites/%s.%s.html" % [report_dir, normalize_path(path), name]
+
+
+static func create_path_output_path(report_dir: String, path: String) -> String:
+	return "%s/path/%s.html" % [report_dir, normalize_path(path)]
+
+
+static func write_html_file(output_path: String, content: String) -> void:
+	var dir := output_path.get_base_dir()
+	if not DirAccess.dir_exists_absolute(dir):
+		@warning_ignore("return_value_discarded")
+		DirAccess.make_dir_recursive_absolute(dir)
+	FileAccess.open(output_path, FileAccess.WRITE).store_string(content)
+
+
 static func get_path_as_link(report: GdUnitReportSummary) -> String:
-	return "../path/%s.html" % report.path().replace("/", ".")
+	return "../path/%s.html" % normalize_path(report.path())
 
 
 static func get_report_path(report: GdUnitReportSummary) -> String:
@@ -179,7 +199,7 @@ static func create_suite_record(report_link: String, report: GdUnitTestSuiteRepo
 	return GdUnitHtmlPatterns.build(GdUnitHtmlPatterns.TABLE_RECORD_TESTSUITE, report, report_link)
 
 
-static func create_test_failure_report(_report_dir :String, report: GdUnitTestCaseReport) -> String:
+static func create_test_failure_report(_report_dir: String, report: GdUnitTestCaseReport) -> String:
 	return GdUnitHtmlPatterns.TABLE_RECORD_TESTCASE\
 		.replace(GdUnitHtmlPatterns.REPORT_STATE, report.report_state().to_lower())\
 		.replace(GdUnitHtmlPatterns.REPORT_STATE_LABEL, report.report_state())\

--- a/addons/gdUnit4/src/reporters/html/GdUnitHtmlPatterns.gd.uid
+++ b/addons/gdUnit4/src/reporters/html/GdUnitHtmlPatterns.gd.uid
@@ -1,1 +1,1 @@
-uid://beu8w7ac54wtn
+uid://bhj2e73y7xypo

--- a/addons/gdUnit4/src/reporters/html/GdUnitHtmlReportWriter.gd
+++ b/addons/gdUnit4/src/reporters/html/GdUnitHtmlReportWriter.gd
@@ -21,7 +21,7 @@ func write(report_path: String, report: GdUnitReportSummary) -> String:
 
 
 func _apply_path_reports(report_dir: String, template: String, report_summaries: Array) -> String:
-	#Dictionary[String, Array[GdUnitReportSummary]]
+	# Dictionary[String, Array[GdUnitReportSummary]]
 	var path_report_mapping := GdUnitByPathReport.sort_reports_by_path(report_summaries)
 	var table_records := PackedStringArray()
 	var paths: Array[String] = []
@@ -45,11 +45,11 @@ func _apply_testsuite_reports(report_dir: String, template: String, test_suite_r
 	return template.replace(GdUnitHtmlPatterns.TABLE_BY_TESTSUITES, "\n".join(table_records))
 
 
-func _write(report_dir :String, report: GdUnitTestSuiteReport) -> String:
+func _write(report_dir: String, report: GdUnitTestSuiteReport) -> String:
 	var template := GdUnitHtmlPatterns.load_template("res://addons/gdUnit4/src/reporters/html/template/suite_report.html")
-	template = GdUnitHtmlPatterns.build(template, report, "")
+	template = GdUnitHtmlPatterns.build(template, report, "", GdUnitHtmlPatterns.get_path_as_link(report))
 
-	var report_output_path := create_output_path(report_dir, report.path(), report.name())
+	var report_output_path := GdUnitHtmlPatterns.create_suite_output_path(report_dir, report.path(), report.name())
 	var test_report_table := PackedStringArray()
 	if not report._failure_reports.is_empty():
 		@warning_ignore("return_value_discarded")
@@ -59,14 +59,5 @@ func _write(report_dir :String, report: GdUnitTestSuiteReport) -> String:
 		test_report_table.append(GdUnitHtmlPatterns.create_test_failure_report(report_output_path, test_report))
 
 	template = template.replace(GdUnitHtmlPatterns.TABLE_BY_TESTCASES, "\n".join(test_report_table))
-
-	var dir := report_output_path.get_base_dir()
-	if not DirAccess.dir_exists_absolute(dir):
-		@warning_ignore("return_value_discarded")
-		DirAccess.make_dir_recursive_absolute(dir)
-	FileAccess.open(report_output_path, FileAccess.WRITE).store_string(template)
+	GdUnitHtmlPatterns.write_html_file(report_output_path, template)
 	return report_output_path
-
-
-static func create_output_path(report_dir :String, path: String, name: String) -> String:
-	return "%s/test_suites/%s.%s.html" % [report_dir, path.replace("/", "."), name]

--- a/addons/gdUnit4/src/reporters/html/GdUnitHtmlReportWriter.gd.uid
+++ b/addons/gdUnit4/src/reporters/html/GdUnitHtmlReportWriter.gd.uid
@@ -1,1 +1,1 @@
-uid://db4mi0fc11575
+uid://dd1c5wlbrp07b

--- a/addons/gdUnit4/src/reporters/xml/JUnitXmlReportWriter.gd.uid
+++ b/addons/gdUnit4/src/reporters/xml/JUnitXmlReportWriter.gd.uid
@@ -1,1 +1,1 @@
-uid://clkydfmu7ojh
+uid://dc6mxx37nrt0i

--- a/addons/gdUnit4/src/reporters/xml/XmlElement.gd.uid
+++ b/addons/gdUnit4/src/reporters/xml/XmlElement.gd.uid
@@ -1,1 +1,1 @@
-uid://3tvam5spapts
+uid://haqt6w7qnxn8

--- a/addons/gdUnit4/src/ui/GdUnitConsole.gd.uid
+++ b/addons/gdUnit4/src/ui/GdUnitConsole.gd.uid
@@ -1,1 +1,1 @@
-uid://gnyub3q4vanm
+uid://bym37nsnovto1

--- a/addons/gdUnit4/src/ui/GdUnitFonts.gd.uid
+++ b/addons/gdUnit4/src/ui/GdUnitFonts.gd.uid
@@ -1,1 +1,1 @@
-uid://cu1d1pquh12l5
+uid://bhch8oj2n0wpj

--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -29,6 +29,6 @@ func _ready() -> void:
 
 func _process(delta: float) -> void:
 	_wait_time += delta
-	if _wait_time > 5.0:
+	if _wait_time > 2.0:
 		_wait_time = 0
 		_command_handler._do_process()

--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd.uid
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd.uid
@@ -1,1 +1,1 @@
-uid://b4gmm88c2hxra
+uid://cf14pg7m3enhs

--- a/addons/gdUnit4/src/ui/GdUnitInspectorTreeConstants.gd.uid
+++ b/addons/gdUnit4/src/ui/GdUnitInspectorTreeConstants.gd.uid
@@ -1,1 +1,1 @@
-uid://wiqsq354np64
+uid://c5f6ibwmd8nly

--- a/addons/gdUnit4/src/ui/GdUnitUiTools.gd.uid
+++ b/addons/gdUnit4/src/ui/GdUnitUiTools.gd.uid
@@ -1,1 +1,1 @@
-uid://bfb0pndqutnqx
+uid://hrxy1iau1f04

--- a/addons/gdUnit4/src/ui/ScriptEditorControls.gd.uid
+++ b/addons/gdUnit4/src/ui/ScriptEditorControls.gd.uid
@@ -1,1 +1,1 @@
-uid://cuods3rre6f1t
+uid://dud46novqwqpy

--- a/addons/gdUnit4/src/ui/menu/GdUnitContextMenuItem.gd.uid
+++ b/addons/gdUnit4/src/ui/menu/GdUnitContextMenuItem.gd.uid
@@ -1,1 +1,1 @@
-uid://dfm15wq8tktpo
+uid://d3k6jw1peofeg

--- a/addons/gdUnit4/src/ui/menu/GdUnitEditorFileSystemContextMenuHandler.gd
+++ b/addons/gdUnit4/src/ui/menu/GdUnitEditorFileSystemContextMenuHandler.gd
@@ -9,6 +9,7 @@ func _init() -> void:
 		if script == null:
 			return false
 		return GdUnitTestSuiteScanner.is_test_suite(script) == is_ts
+	# setup shortcuts
 	_context_menus.append(GdUnitContextMenuItem.new(
 		GdUnitCommandFileSystemRunTests.ID,
 		"Run Testsuites",
@@ -20,18 +21,25 @@ func _init() -> void:
 		is_test_suite.bind(true)
 	))
 
-	# setup shortcuts
-	for menu_item in _context_menus:
-		if menu_item.shortcut():
-			var cb := func call(...files: Array) -> void:
-				var paths: Array = files[0]
-				menu_item.execute.callv(paths)
-			add_menu_shortcut(menu_item.shortcut(), cb)
-
 
 func _popup_menu(paths: PackedStringArray) -> void:
+	# Filter for directories and test suite files
+	var valid_paths := Array(paths)\
+		.filter(func(path: String) -> bool:
+			if DirAccess.dir_exists_absolute(path):
+				return true
+			if path.get_extension() in ["gd", "cs"]:
+				var script := GdUnitTestSuiteScanner.load_with_disabled_warnings(path)
+				return GdUnitTestSuiteScanner.is_test_suite(script)
+			return false)
+
+	# If no valid paths selected don't extend the context menu
+	if valid_paths.is_empty():
+		return
+
 	for menu_item in _context_menus:
 		if menu_item.shortcut():
+			add_menu_shortcut(menu_item.shortcut(), menu_item.execute.bindv(valid_paths).unbind(1))
 			add_context_menu_item_from_shortcut(menu_item.name, menu_item.shortcut(), menu_item.icon)
 		else:
-			add_context_menu_item(menu_item.name, menu_item.execute.bindv(paths).unbind(1), menu_item.icon)
+			add_context_menu_item(menu_item.name, menu_item.execute.bindv(valid_paths).unbind(1), menu_item.icon)

--- a/addons/gdUnit4/src/ui/menu/GdUnitEditorFileSystemContextMenuHandler.gd.uid
+++ b/addons/gdUnit4/src/ui/menu/GdUnitEditorFileSystemContextMenuHandler.gd.uid
@@ -1,1 +1,1 @@
-uid://dnkehrpjpqu8n
+uid://bxjkj4bb1mnh0

--- a/addons/gdUnit4/src/ui/menu/GdUnitInspectorContextMenu.gd.uid
+++ b/addons/gdUnit4/src/ui/menu/GdUnitInspectorContextMenu.gd.uid
@@ -1,1 +1,1 @@
-uid://docil6li3gcog
+uid://blniubbjoj57j

--- a/addons/gdUnit4/src/ui/menu/GdUnitScriptEditorContextMenuHandler.gd
+++ b/addons/gdUnit4/src/ui/menu/GdUnitScriptEditorContextMenuHandler.gd
@@ -8,6 +8,7 @@ var _context_menus: Array[GdUnitContextMenuItem] = []
 func _init() -> void:
 	var is_test_suite := func is_visible(script: Script, is_ts: bool) -> bool:
 		return GdUnitTestSuiteScanner.is_test_suite(script) == is_ts
+	# setup shortcuts
 	_context_menus.append(GdUnitContextMenuItem.new(
 		GdUnitCommandScriptEditorRunTests.ID,
 		"Run Tests",
@@ -24,11 +25,6 @@ func _init() -> void:
 		is_test_suite.bind(false)
 	))
 
-	# setup shortcuts
-	for menu_item in _context_menus:
-		if menu_item.shortcut():
-			add_menu_shortcut(menu_item.shortcut(), menu_item.execute.unbind(1))
-
 
 func _popup_menu(_paths: PackedStringArray) -> void:
 	var current_script := EditorInterface.get_script_editor().get_current_script()
@@ -36,6 +32,7 @@ func _popup_menu(_paths: PackedStringArray) -> void:
 	for menu_item in _context_menus:
 		if menu_item.is_visible(current_script):
 			if menu_item.shortcut():
+				add_menu_shortcut(menu_item.shortcut(), menu_item.execute.unbind(1))
 				add_context_menu_item_from_shortcut(menu_item.name, menu_item.shortcut())
 			else:
 				add_context_menu_item(menu_item.name, menu_item.execute.unbind(1))

--- a/addons/gdUnit4/src/ui/menu/GdUnitScriptEditorContextMenuHandler.gd.uid
+++ b/addons/gdUnit4/src/ui/menu/GdUnitScriptEditorContextMenuHandler.gd.uid
@@ -1,1 +1,1 @@
-uid://pa7kacqkw534
+uid://cbd32nj7kytk4

--- a/addons/gdUnit4/src/ui/parts/InspectorMonitor.gd.uid
+++ b/addons/gdUnit4/src/ui/parts/InspectorMonitor.gd.uid
@@ -1,1 +1,1 @@
-uid://c1v33376gwdte
+uid://byyvuc4m1xqo4

--- a/addons/gdUnit4/src/ui/parts/InspectorProgressBar.gd.uid
+++ b/addons/gdUnit4/src/ui/parts/InspectorProgressBar.gd.uid
@@ -1,1 +1,1 @@
-uid://rpsib775cxv6
+uid://dtupmu4quyo1q

--- a/addons/gdUnit4/src/ui/parts/InspectorStatusBar.gd.uid
+++ b/addons/gdUnit4/src/ui/parts/InspectorStatusBar.gd.uid
@@ -1,1 +1,1 @@
-uid://0p3tho13fov
+uid://cixgnmbabr55j

--- a/addons/gdUnit4/src/ui/parts/InspectorToolBar.gd.uid
+++ b/addons/gdUnit4/src/ui/parts/InspectorToolBar.gd.uid
@@ -1,1 +1,1 @@
-uid://1a14wvl3q2p6
+uid://bfjman3exgjls

--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd.uid
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd.uid
@@ -1,1 +1,1 @@
-uid://bobmvycd4e60c
+uid://cgicyhvxqefib

--- a/addons/gdUnit4/src/ui/settings/GdUnitInputCapture.gd.uid
+++ b/addons/gdUnit4/src/ui/settings/GdUnitInputCapture.gd.uid
@@ -1,1 +1,1 @@
-uid://brsfkerb326sh
+uid://ddsayxkc0fluf

--- a/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.gd.uid
+++ b/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.gd.uid
@@ -1,1 +1,1 @@
-uid://blp3apwqfd8o6
+uid://bhuow2h2qq7gd

--- a/addons/gdUnit4/src/ui/settings/GdUnitSettingsTabHooks.gd
+++ b/addons/gdUnit4/src/ui/settings/GdUnitSettingsTabHooks.gd
@@ -2,204 +2,143 @@
 extends ScrollContainer
 
 
-@onready var _hooks_tree: Tree = %hooks_tree
+@onready var _hooks_list: VBoxContainer = %hook_list
+@onready var _hook_row_template: Panel = %row_template
 @onready var _hook_description: RichTextLabel = %hook_description
 @onready var _btn_move_up: Button = %hook_actions/btn_move_up
 @onready var _btn_move_down: Button = %hook_actions/btn_move_down
 @onready var _btn_delete: Button = %hook_actions/btn_delete_hook
 @onready var _select_hook_dlg: FileDialog = %select_hook_dlg
-@onready var _error_msg_popup :AcceptDialog = %error_msg_popup
+@onready var _error_msg_popup: AcceptDialog = %error_msg_popup
 
-var _selected_hook_item: TreeItem = null
-var _root: TreeItem
-var _system_box_style: StyleBoxFlat
-var _priority_box_style: StyleBoxFlat
+
+var _selected_row: Control = null
+var selected_style := StyleBoxFlat.new()
+
 
 func _ready() -> void:
-	_setup_styles()
-	_setup_buttons()
-	_setup_tree()
-	_load_registered_hooks()
+	selected_style.set_border_color(Color.DODGER_BLUE)
+	selected_style.set_border_width_all(2)
+	selected_style.set_corner_radius_all(4)
+	selected_style.set_draw_center(false)
+
+	for hook: GdUnitTestSessionHook in GdUnitTestSessionHookService.instance().enigne_hooks:
+		_create_hook_row(hook)
+
+	_update_focus_relations()
+
+	if _hooks_list.get_child_count() > 0:
+		_select_row(_hooks_list.get_child(0))
 
 
-func _setup_styles() -> void:
-	_system_box_style = StyleBoxFlat.new()
-	_system_box_style.bg_color = Color(1.0, 0.76, 0.03, 1)
-	_system_box_style.corner_radius_top_left = 6
-	_system_box_style.corner_radius_top_right = 6
-	_system_box_style.corner_radius_bottom_left = 6
-	_system_box_style.corner_radius_bottom_right = 6
-	_priority_box_style = _system_box_style.duplicate()
-	_priority_box_style.bg_color = Color(0.26, 0.54, 0.89, 1)
+func _update_focus_relations() -> void:
+	var row_count := _hooks_list.get_child_count()
+	for hook_index in row_count:
+		var current_hook: Control = _hooks_list.get_child(hook_index)
+		var previous_hook: Control = current_hook if hook_index == 0 else _hooks_list.get_child(hook_index - 1)
+		var next_hook: Control = current_hook if hook_index >= row_count - 1 else _hooks_list.get_child(hook_index + 1)
+		current_hook.focus_neighbor_top = previous_hook.get_path()
+		current_hook.set_focus_previous(previous_hook.get_path())
+		current_hook.focus_neighbor_bottom = next_hook.get_path()
+		current_hook.set_focus_next(next_hook.get_path())
 
 
-func _setup_buttons() -> void:
-	#if Engine.is_editor_hint():
-	#	_btn_move_up.icon = GdUnitUiTools.get_icon("MoveUp")
-	#	_btn_move_down.icon = GdUnitUiTools.get_icon("MoveDown")
-	#	_btn_add.icon = GdUnitUiTools.get_icon("Add")
-	#	_btn_delete.icon = GdUnitUiTools.get_icon("Remove")
-	pass
-
-
-func _setup_tree() -> void:
-	_hooks_tree.clear()
-	_root = _hooks_tree.create_item()
-	_hooks_tree.set_columns(2)
-	_hooks_tree.set_column_custom_minimum_width(1, 32)
-	_hooks_tree.set_column_expand(1, false)
-	_hooks_tree.set_hide_root(true)
-	_hooks_tree.set_hide_folding(true)
-	_hooks_tree.set_select_mode(Tree.SELECT_SINGLE)
-	_hooks_tree.item_selected.connect(_on_hook_selected)
-	_hooks_tree.item_edited.connect(_on_item_edited)
-
-
-func _load_registered_hooks() -> void:
-	var hook_service := GdUnitTestSessionHookService.instance()
-	for hook: GdUnitTestSessionHook in hook_service.enigne_hooks:
-		_create_hook_tree_item(hook)
-
-	# Select first item if any
-	if _root.get_child_count() > 0:
-		var first_item: TreeItem = _root.get_first_child()
-		first_item.select(0)
-		_on_hook_selected()
-
-
-func _create_hook_tree_item(hook: GdUnitTestSessionHook) -> TreeItem:
-	var item: TreeItem = _hooks_tree.create_item(_root)
-	item.set_custom_minimum_height(26)
-	# Column 0: Hook info with custom drawing
-	item.set_cell_mode(0, TreeItem.CELL_MODE_CUSTOM)
-	item.set_custom_draw_callback(0, _draw_hook_item)
-	item.set_editable(0, false)
-	item.set_metadata(0, hook)
-	# Column 1: Checkbox for enable/disable
-	item.set_cell_mode(1, TreeItem.CELL_MODE_CHECK)
-	item.set_checked(1, GdUnitTestSessionHookService.is_enabled(hook))
-	item.set_editable(1, true)
-	item.set_custom_bg_color(1, _hook_bg_color(hook))
-	item.set_tooltip_text(1, "Enable/Disable the Hook")
-	item.propagate_check(1)
-
-	if _is_system_hook(hook):
-		item.set_tooltip_text(0, "System hook - (Read-only)")
-	else:
-		item.set_tooltip_text(0, "User hook")
-	return item
-
-
-func _hook_bg_color(hook: GdUnitTestSessionHook) -> Color:
-	if _is_system_hook(hook):
-		return Color(0.133, 0.118, 0.090, 1)  # Brownish background for system hooks
-	return Color(0.176, 0.196, 0.235, 1)  # Dark background #2d3142
-
-
-func _draw_hook_item(item: TreeItem, rect: Rect2) -> void:
-	var hook := _get_hook(item)
+func _create_hook_row(hook: GdUnitTestSessionHook) -> Control:
 	var is_system := _is_system_hook(hook)
-	var is_selected := item == _selected_hook_item
+	var panel: Panel = _hook_row_template.duplicate()
 
-	# Draw background
-	var bg_color := _hook_bg_color(hook) # Dark background #2d3142
-	if is_selected:
-		bg_color = bg_color.lerp(Color(0.2, 0.4, 0.6, 0.3), 0.5)  # Blue tint for selection
-	_hooks_tree.draw_rect(rect, bg_color)
+	panel.visible = true
+	panel.set_meta("hook", hook)
+	panel.tooltip_text = "System hook - (Read-only)" if is_system else "User hook"
+	panel.focus_entered.connect(_select_row.bind(panel))
+	panel.gui_input.connect(func(event: InputEvent) -> void:
+		@warning_ignore("unsafe_property_access")
+		if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+			_select_row(panel)
+			panel.accept_event()
+	)
 
-	# Draw left border for system hooks
+	# Left color indicator border
+	var indicator: ColorRect = panel.find_child("Indicator", true, false)
+	indicator.color = Color(1.0, 0.76, 0.03, 1) if is_system else Color(0.26, 0.54, 0.89, 1)
+
+	# Hook name
+	var name_label: Label = panel.find_child("HookName", true, false)
+	name_label.text = hook.name
+
+	# System badge
 	if is_system:
-		var border_rect := Rect2(rect.position.x, rect.position.y, 3, rect.size.y)
-		_hooks_tree.draw_rect(border_rect, Color(1.0, 0.76, 0.03, 1))  # Yellow border
+		var badge: Control = panel.find_child("SystemBadge", true, false)
+		badge.visible = true
 
-	var font := _hooks_tree.get_theme_default_font()
+	# Enable/disable toggle
+	var check: CheckButton = panel.find_child("Enabled", true, false)
+	check.button_pressed = GdUnitTestSessionHookService.is_enabled(hook)
+	check.toggled.connect(func(enabled: bool) -> void:
+		GdUnitTestSessionHookService.instance().enable_hook(hook, enabled)
+	)
 
-	# Draw hook name
-	var hook_name := hook.name
-	var text_pos := Vector2(rect.position.x + ( 15 if is_system else 12), rect.position.y + 18)
-	var text_color := Color(0.95, 0.95, 0.95, 1)
-	_hooks_tree.draw_string(font, text_pos, hook_name, HORIZONTAL_ALIGNMENT_LEFT, -1, 14, text_color)
-
-	# Draw system badge if needed
-	if is_system:
-		var badge_x := rect.position.x + rect.end.x - 100
-		var badge_y := rect.position.y + 14
-		var system_badge_rect := Rect2(badge_x, badge_y-8, 48, 16)
-		_hooks_tree.draw_style_box(_system_box_style, system_badge_rect)
-
-		var system_text_pos := Vector2(badge_x + 4, badge_y + 4)
-		var system_font_size := 10
-		_hooks_tree.draw_string(font, system_text_pos, "SYSTEM", HORIZONTAL_ALIGNMENT_CENTER, -1, system_font_size, Color(0.1, 0.1, 0.1, 1))
+	_hooks_list.add_child(panel)
+	return panel
 
 
-func _create_hook_display_text(hook_name: String, priority: int, is_system: bool) -> String:
-	var text := hook_name + "\n"
-	text += "Priority: [color=#4299e1][bgcolor=#4299e1]  " + str(priority) + "  [/bgcolor][/color]"
+func _select_row(row: Node) -> void:
+	if _selected_row == row:
+		return
 
-	if is_system:
-		text += " [color=#1a202c][bgcolor=#ffc107]  SYSTEM  [/bgcolor][/color]"
+	if _selected_row != null and is_instance_valid(_selected_row):
+		_selected_row.remove_theme_stylebox_override("panel")
 
-	return text
+	_selected_row = row
+
+	if _selected_row != null:
+		_selected_row.grab_focus()
+
+		_selected_row.add_theme_stylebox_override("panel", selected_style)
+
+	_update_hook_buttons()
+	_update_hook_description()
 
 
 func _update_hook_description() -> void:
-	if _selected_hook_item == null:
+	if _selected_row == null:
 		_hook_description.text = "[i]Select a hook to view its description[/i]"
 		return
-	_hook_description.text = _get_hook(_selected_hook_item).description
+	_hook_description.text = _get_hook(_selected_row).description
 
 
 func _update_hook_buttons() -> void:
-	# Is nothing selected disable the move and delete buttons
-	if _selected_hook_item == null:
+	if _selected_row == null:
 		_btn_move_up.disabled = true
 		_btn_move_down.disabled = true
 		_btn_delete.disabled = true
 		return
 
-	var hook := _get_hook(_selected_hook_item)
-	var is_system := _is_system_hook(hook)
-
-	# Disable the move and delete buttons for system hooks by default
-	if is_system:
+	var hook := _get_hook(_selected_row)
+	if _is_system_hook(hook):
 		_btn_move_up.disabled = true
 		_btn_move_down.disabled = true
 		_btn_delete.disabled = true
 		return
 
-	var prev_item: TreeItem = _selected_hook_item.get_prev()
-	var next_item: TreeItem = _selected_hook_item.get_next()
+	var idx := _selected_row.get_index()
+	var count := _hooks_list.get_child_count()
+	var prev: Control = _hooks_list.get_child(idx - 1) if idx > 0 else null
+	var next: Control = _hooks_list.get_child(idx + 1) if idx + 1 < count else null
 
-	if prev_item != null:
-		var prev_hook := _get_hook(prev_item)
-		_btn_move_up.disabled = _is_system_hook(prev_hook)
-
-	_btn_move_down.disabled = next_item == null
+	_btn_move_up.disabled = prev == null or _is_system_hook(_get_hook(prev))
+	_btn_move_down.disabled = next == null
 	_btn_delete.disabled = false
 
 
-static func _get_hook(item: TreeItem) -> GdUnitTestSessionHook:
-	return item.get_metadata(0)
+static func _get_hook(row: Control) -> GdUnitTestSessionHook:
+	return row.get_meta("hook")
 
 
 static func _is_system_hook(hook: GdUnitTestSessionHook) -> bool:
 	if hook == null:
 		return false
-	return hook.get_meta("SYSTEM_HOOK")
-
-
-func _on_hook_selected() -> void:
-	_selected_hook_item = _hooks_tree.get_selected()
-	_update_hook_buttons()
-	_update_hook_description()
-
-
-func _on_item_edited() -> void:
-	var selected_hook_item := _hooks_tree.get_selected()
-	if selected_hook_item != null:
-		var hook := _get_hook(selected_hook_item)
-		var is_enabled := selected_hook_item.is_checked(1)
-		GdUnitTestSessionHookService.instance().enable_hook(hook, is_enabled)
+	return hook.get_meta("SYSTEM_HOOK", false)
 
 
 func _on_btn_add_hook_pressed() -> void:
@@ -226,30 +165,44 @@ func _on_select_hook_dlg_confirmed() -> void:
 		_error_msg_popup.show()
 		return
 
-	var hook_added := _create_hook_tree_item(hook)
-	_hooks_tree.set_selected(hook_added, 0)
+	var row := _create_hook_row(hook)
+	_update_focus_relations()
+	_select_row(row)
 
 
 func _on_btn_delete_hook_pressed() -> void:
-	if _selected_hook_item != null:
-		_root.remove_child(_selected_hook_item)
-		GdUnitTestSessionHookService.instance()\
-			.unregister(_get_hook(_selected_hook_item))
-		_selected_hook_item = null
-		_update_hook_buttons()
+	if _selected_row == null:
+		return
+	GdUnitTestSessionHookService.instance().unregister(_get_hook(_selected_row))
+
+	_hooks_list.remove_child(_selected_row)
+	_selected_row.queue_free()
+
+	_update_focus_relations()
+	_select_row(_hooks_list.find_next_valid_focus())
 
 
 func _on_btn_move_up_pressed() -> void:
-	var prev := _selected_hook_item.get_prev()
-	_selected_hook_item.move_before(prev)
-	GdUnitTestSessionHookService.instance()\
-		.move_before(_get_hook(_selected_hook_item), _get_hook(prev))
+	if _selected_row == null:
+		return
+	var idx := _selected_row.get_index() - 1
+	if idx <= 0:
+		return
+	var prev: Control = _hooks_list.get_child(idx)
+	_hooks_list.move_child(_selected_row, idx)
+	GdUnitTestSessionHookService.instance().move_before(_get_hook(_selected_row), _get_hook(prev))
+	_update_focus_relations()
 	_update_hook_buttons()
 
 
 func _on_btn_move_down_pressed() -> void:
-	var next := _selected_hook_item.get_next()
-	_selected_hook_item.move_after(next)
-	GdUnitTestSessionHookService.instance()\
-		.move_after(_get_hook(_selected_hook_item), _get_hook(next))
+	if _selected_row == null:
+		return
+	var idx := _selected_row.get_index() + 1
+	if idx >= _hooks_list.get_child_count():
+		return
+	var next: Control = _hooks_list.get_child(idx)
+	_hooks_list.move_child(_selected_row, idx)
+	GdUnitTestSessionHookService.instance().move_after(_get_hook(_selected_row), _get_hook(next))
+	_update_focus_relations()
 	_update_hook_buttons()

--- a/addons/gdUnit4/src/ui/settings/GdUnitSettingsTabHooks.gd.uid
+++ b/addons/gdUnit4/src/ui/settings/GdUnitSettingsTabHooks.gd.uid
@@ -1,1 +1,1 @@
-uid://c3igu74fy8t8x
+uid://vnt7fd0i5dmc

--- a/addons/gdUnit4/src/ui/settings/GdUnitSettingsTabHooks.tscn
+++ b/addons/gdUnit4/src/ui/settings/GdUnitSettingsTabHooks.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://41l7a46fol5m"]
+[gd_scene format=3 uid="uid://41l7a46fol5m"]
 
 [ext_resource type="Script" path="res://addons/gdUnit4/src/ui/settings/GdUnitSettingsTabHooks.gd" id="1_8yffn"]
 
@@ -50,7 +50,23 @@ data = {
 [sub_resource type="ImageTexture" id="ImageTexture_4h4u1"]
 image = SubResource("Image_rewru")
 
-[node name="Hooks" type="ScrollContainer"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_h5sr5"]
+content_margin_left = 4.0
+content_margin_top = 2.0
+content_margin_right = 4.0
+content_margin_bottom = 2.0
+bg_color = Color(1, 0.85490197, 0.011764706, 1)
+border_width_left = 2
+border_width_top = 4
+border_width_right = 2
+border_width_bottom = 4
+border_color = Color(0.8, 0.8, 0.8, 0)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+
+[node name="Hooks" type="ScrollContainer" unique_id=659565185]
 custom_minimum_size = Vector2(400, 300)
 anchors_preset = 15
 anchor_right = 1.0
@@ -62,70 +78,81 @@ size_flags_vertical = 3
 script = ExtResource("1_8yffn")
 metadata/_tab_index = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="."]
+[node name="HBoxContainer" type="HBoxContainer" parent="." unique_id=1746177026]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="hooks_content" type="VBoxContainer" parent="HBoxContainer"]
+[node name="hooks_content" type="VBoxContainer" parent="HBoxContainer" unique_id=1756623882]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="hooks_tree" type="Tree" parent="HBoxContainer/hooks_content"]
+[node name="Panel" type="Panel" parent="HBoxContainer/hooks_content" unique_id=1467652907]
+modulate = Color(0.827451, 0.827451, 0.827451, 1)
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="hook_scroll" type="ScrollContainer" parent="HBoxContainer/hooks_content/Panel" unique_id=1296435931]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_vertical = 3
+
+[node name="hook_list" type="VBoxContainer" parent="HBoxContainer/hooks_content/Panel/hook_scroll" unique_id=1329270012]
 unique_name_in_owner = true
-layout_direction = 2
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-hide_folding = true
-hide_root = true
 
-[node name="hook_description" type="RichTextLabel" parent="HBoxContainer/hooks_content"]
+[node name="hook_description" type="RichTextLabel" parent="HBoxContainer/hooks_content" unique_id=1554657128]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 120)
 layout_mode = 2
 size_flags_vertical = 2
 bbcode_enabled = true
-text = "The test result Html reporting hook."
+text = "<hook description>"
 scroll_active = false
 
-[node name="hook_actions" type="VBoxContainer" parent="HBoxContainer"]
+[node name="hook_actions" type="VBoxContainer" parent="HBoxContainer" unique_id=1441205618]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
-size_flags_horizontal = 0
+size_flags_horizontal = 8
 theme_override_constants/separation = 5
 
-[node name="btn_move_up" type="Button" parent="HBoxContainer/hook_actions"]
+[node name="btn_move_up" type="Button" parent="HBoxContainer/hook_actions" unique_id=1909528536]
 layout_mode = 2
 tooltip_text = "Move hook up in priority"
 disabled = true
 icon = SubResource("ImageTexture_77fm0")
 icon_alignment = 1
 
-[node name="btn_move_down" type="Button" parent="HBoxContainer/hook_actions"]
+[node name="btn_move_down" type="Button" parent="HBoxContainer/hook_actions" unique_id=1385113071]
 layout_mode = 2
 tooltip_text = "Move hook down in priority"
 disabled = true
 icon = SubResource("ImageTexture_rewru")
 icon_alignment = 1
 
-[node name="btn_add_hook" type="Button" parent="HBoxContainer/hook_actions"]
+[node name="btn_add_hook" type="Button" parent="HBoxContainer/hook_actions" unique_id=338115845]
 layout_mode = 2
 tooltip_text = "Add new hook"
 icon = SubResource("ImageTexture_manhx")
 icon_alignment = 1
 
-[node name="btn_delete_hook" type="Button" parent="HBoxContainer/hook_actions"]
+[node name="btn_delete_hook" type="Button" parent="HBoxContainer/hook_actions" unique_id=642037387]
 layout_mode = 2
 tooltip_text = "Delete selected hook"
 disabled = true
 icon = SubResource("ImageTexture_4h4u1")
 icon_alignment = 1
 
-[node name="select_hook_dlg" type="FileDialog" parent="."]
+[node name="select_hook_dlg" type="FileDialog" parent="." unique_id=2043681690]
 unique_name_in_owner = true
 disable_3d = true
 title = "Open a File"
@@ -135,10 +162,62 @@ ok_button_text = "Open"
 file_mode = 0
 filters = PackedStringArray("*.gd")
 
-[node name="error_msg_popup" type="AcceptDialog" parent="."]
+[node name="error_msg_popup" type="AcceptDialog" parent="." unique_id=1430197292]
 unique_name_in_owner = true
 initial_position = 3
 current_screen = 0
+
+[node name="row_template" type="Panel" parent="." unique_id=2068077019]
+unique_name_in_owner = true
+visible = false
+custom_minimum_size = Vector2(0, 26)
+layout_mode = 2
+size_flags_horizontal = 3
+focus_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="row_template" unique_id=421161803]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Spacer1" type="MarginContainer" parent="row_template/HBoxContainer" unique_id=1388548361]
+clip_contents = true
+custom_minimum_size = Vector2(12, 0)
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_constants/margin_left = 3
+theme_override_constants/margin_top = 3
+theme_override_constants/margin_bottom = 3
+
+[node name="Indicator" type="ColorRect" parent="row_template/HBoxContainer/Spacer1" unique_id=695255812]
+custom_minimum_size = Vector2(4, 0)
+layout_mode = 2
+color = Color(1, 1, 0, 1)
+
+[node name="HookName" type="Label" parent="row_template/HBoxContainer" unique_id=167022167]
+layout_mode = 2
+size_flags_horizontal = 2
+text = "<hook name>"
+
+[node name="SystemBadge" type="PanelContainer" parent="row_template/HBoxContainer" unique_id=1220764160]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_styles/panel = SubResource("StyleBoxFlat_h5sr5")
+
+[node name="Label" type="Label" parent="row_template/HBoxContainer/SystemBadge" unique_id=1972968522]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.008202022, 0.008202025, 0.008202025, 1)
+theme_override_font_sizes/font_size = 10
+text = "SYSTEM"
+
+[node name="Enabled" type="CheckButton" parent="row_template/HBoxContainer" unique_id=365063095]
+layout_mode = 2
+size_flags_vertical = 4
+tooltip_text = "Enable/Disable the Hook"
+focus_mode = 0
 
 [connection signal="pressed" from="HBoxContainer/hook_actions/btn_move_up" to="." method="_on_btn_move_up_pressed"]
 [connection signal="pressed" from="HBoxContainer/hook_actions/btn_move_down" to="." method="_on_btn_move_down_pressed"]

--- a/addons/gdUnit4/src/ui/templates/TestSuiteTemplate.gd.uid
+++ b/addons/gdUnit4/src/ui/templates/TestSuiteTemplate.gd.uid
@@ -1,1 +1,1 @@
-uid://6nfo6w2wfdg8
+uid://nohefmuilvpn

--- a/addons/gdUnit4/src/update/GdMarkDownReader.gd.uid
+++ b/addons/gdUnit4/src/update/GdMarkDownReader.gd.uid
@@ -1,1 +1,1 @@
-uid://dldfbcyuvjpxn
+uid://bgtu2ww2c5hxd

--- a/addons/gdUnit4/src/update/GdUnitPatch.gd.uid
+++ b/addons/gdUnit4/src/update/GdUnitPatch.gd.uid
@@ -1,1 +1,1 @@
-uid://bhcmm610cy1db
+uid://bphibm1tahlsn

--- a/addons/gdUnit4/src/update/GdUnitPatcher.gd.uid
+++ b/addons/gdUnit4/src/update/GdUnitPatcher.gd.uid
@@ -1,1 +1,1 @@
-uid://pqnm4y7tnff2
+uid://cfleh5ny5lmwh

--- a/addons/gdUnit4/src/update/GdUnitUpdate.gd.uid
+++ b/addons/gdUnit4/src/update/GdUnitUpdate.gd.uid
@@ -1,1 +1,1 @@
-uid://brtytkiijfldq
+uid://cmysa7k4afo16

--- a/addons/gdUnit4/src/update/GdUnitUpdateClient.gd.uid
+++ b/addons/gdUnit4/src/update/GdUnitUpdateClient.gd.uid
@@ -1,1 +1,1 @@
-uid://n5l8b1mknuy8
+uid://8rfvtgqnpa3h

--- a/addons/gdUnit4/src/update/GdUnitUpdateNotify.gd.uid
+++ b/addons/gdUnit4/src/update/GdUnitUpdateNotify.gd.uid
@@ -1,1 +1,1 @@
-uid://datpg3ump0h6e
+uid://c11k2n3cdeiw3

--- a/project.godot
+++ b/project.godot
@@ -16,7 +16,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 
 config/name="Beehave"
 run/main_scene="res://examples/beehave_test_scene.tscn"
-config/features=PackedStringArray("4.6")
+config/features=PackedStringArray("4.7")
 boot_splash/stretch_mode=0
 boot_splash/image="res://splash.png"
 config/icon="res://icon.png"

--- a/test/actions/no_return_action.gd
+++ b/test/actions/no_return_action.gd
@@ -1,5 +1,5 @@
 class_name NoReturnAction extends ActionLeaf
 
 
-func tick(_actor: Node, blackboard: Blackboard):
-	pass
+func tick(_actor: Node, _blackboard: Blackboard) -> int:
+	return -1

--- a/test/blackboard/blackboard_register_action.gd
+++ b/test/blackboard/blackboard_register_action.gd
@@ -3,6 +3,6 @@ extends ActionLeaf
 var blackboard
 
 
-func tick(actor, blackboard: Blackboard):
+func tick(actor: Node, blackboard: Blackboard) -> int:
 	self.blackboard = blackboard
 	return SUCCESS


### PR DESCRIPTION
Godot 4.7 changed some of the GDScript parsing and we had some script bugs that previously did not throw. Those are now addressed.